### PR TITLE
A few UI hot fixes

### DIFF
--- a/ArgusWeb/app/js/controllers/alerts.js
+++ b/ArgusWeb/app/js/controllers/alerts.js
@@ -37,9 +37,9 @@ angular.module('argus.controllers.alerts', ['ngResource'])
 
 	$scope.refreshAlerts = function () {
 		delete $sessionStorage.cachedAlerts;
-        delete $scope.alerts;
+    delete $scope.alerts;
 		getAlerts();
-	}
+	};
 
     $scope.addAlert = function () {
         var alert = {
@@ -59,7 +59,7 @@ angular.module('argus.controllers.alerts', ['ngResource'])
     };
 
     $scope.enableAlert = function (alert, enabled) {
-        if (!alert.enabled === enabled) {
+        if (alert.enabled !== enabled) {
             Alerts.get({alertId: alert.id}, function(updated) {
                 updated.enabled = enabled;
                 Alerts.update({alertId: alert.id}, updated, function (result) {

--- a/ArgusWeb/app/js/controllers/dashboards.js
+++ b/ArgusWeb/app/js/controllers/dashboards.js
@@ -23,6 +23,7 @@ angular.module('argus.controllers.dashboards', ['ngResource', 'ui.codemirror'])
 .controller('Dashboards', ['Auth', '$scope', 'growl', 'Dashboards', '$sessionStorage', function (Auth, $scope, growl, Dashboards, $sessionStorage) {
 
     $scope.dashboards = [];
+    $scope.dashboardsLoaded = false;
     var sharedDashboards = [];
     var usersDashboards = [];
     var remoteUser = Auth.remoteUser();
@@ -92,6 +93,7 @@ angular.module('argus.controllers.dashboards', ['ngResource', 'ui.codemirror'])
     $scope.refreshDashboards = function () {
         delete $sessionStorage.cachedDashboards;
         delete $scope.dashboards;
+        $scope.dashboardsLoaded = false;
         Dashboards.getMeta().$promise.then(function(dashboards) {
             setDashboardsAfterLoading(dashboards);
             $sessionStorage.cachedDashboards = dashboards;

--- a/ArgusWeb/app/js/controllers/dashboards.js
+++ b/ArgusWeb/app/js/controllers/dashboards.js
@@ -48,7 +48,9 @@ angular.module('argus.controllers.dashboards', ['ngResource', 'ui.codemirror'])
 
     // TODO: refactor to DashboardService
     $scope.getDashboards = function(shared) {
-        $scope.dashboards = shared? sharedDashboards: usersDashboards;
+        if ($scope.dashboardsLoaded) {
+            $scope.dashboards = shared? sharedDashboards: usersDashboards;
+        }
         $scope.shared = shared;
         $sessionStorage.shared = shared;
     };
@@ -98,7 +100,7 @@ angular.module('argus.controllers.dashboards', ['ngResource', 'ui.codemirror'])
             setDashboardsAfterLoading(dashboards);
             $sessionStorage.cachedDashboards = dashboards;
         });
-    }
+    };
 
     // TODO: refactor to DashboardService
     $scope.addDashboard = function () {

--- a/ArgusWeb/app/js/controllers/main.js
+++ b/ArgusWeb/app/js/controllers/main.js
@@ -1,5 +1,5 @@
 angular.module('argus.controllers.main', [])
-.controller('Main', ['$scope', '$location', 'Auth', function ($scope, $location, Auth) {
+.controller('Main', ['$scope', '$location', 'Auth', '$sessionStorage', function ($scope, $location, Auth, $sessionStorage) {
 
     $scope.login = function (username, password) {
     	if(username.indexOf("@") != -1) {
@@ -19,4 +19,7 @@ angular.module('argus.controllers.main', [])
     $scope.isPrivileged = function () {
         return Auth.isPrivileged();
     };
+
+    // delete session cache when the entire page is reloaded i.e. refresh the tab
+    $sessionStorage.$reset();
 }]);


### PR DESCRIPTION
1. Allow browser refresh to trigger API query call for dashboard/alert lists.
2. Show loading spinner after the reload button is pressed.
3. Prevent tab switching within dashboard list when reload button is pressed. 

All of the above are in the develop branch as well.