### PR TITLE
Issue #323 set maven-compiler-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,15 @@
         <filters>
             <filter>${top}/argus-build.properties</filter>
         </filters>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.6.0</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>


### PR DESCRIPTION
Set the maven-compiler-plugin to 3.6.0 to avoid compiler errors in #323 