### PR TITLE
Tooltip Update

### DIFF
--- a/ArgusWeb/app/js/config.js
+++ b/ArgusWeb/app/js/config.js
@@ -1,8 +1,8 @@
 /*! Copyright (c) 2016, Salesforce.com, Inc.
  * All rights reserved.
- *  
+ *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
- *   
+ *
  *      Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
  *
  *      Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the

--- a/ArgusWeb/app/js/config.js
+++ b/ArgusWeb/app/js/config.js
@@ -1,8 +1,8 @@
 /*! Copyright (c) 2016, Salesforce.com, Inc.
  * All rights reserved.
- *
+ *  
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
- *
+ *   
  *      Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
  *
  *      Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the

--- a/ArgusWeb/app/js/directives/charts/chart.js
+++ b/ArgusWeb/app/js/directives/charts/chart.js
@@ -25,6 +25,12 @@ function(Metrics, Annotations, ChartRenderingService, ChartDataProcessingService
             // use graphClassName to bind all the graph element of a metric together
             lineChartScope.series[i].graphClassName = newChartId + "_graph" + (i + 1);
         }
+        // sort series alphabetically
+        lineChartScope.series = lineChartScope.series.sort(function(a, b) {
+            var textA = a.name.toUpperCase();
+            var textB = b.name.toUpperCase();
+            return (textA < textB) ? -1 : (textA > textB) ? 1 : 0;
+        });
 
         // append, compile, & attach new scope to line-chart directive
         angular.element("#" + newChartId).append( $compile('<line-chart chartConfig="chartConfig" series="series" dateconfig="dateConfig"></line-chart>')(lineChartScope) );

--- a/ArgusWeb/app/js/directives/charts/lineChart.js
+++ b/ArgusWeb/app/js/directives/charts/lineChart.js
@@ -428,6 +428,8 @@ angular.module('argus.directives.charts.lineChart', [])
                         datapoints.push({data: d, graphClassName: metric.graphClassName, name: metric.name});
                     }
                 });
+                // TODO: sort items in tooltip
+                datapoints = datapoints.sort(function(a,b){return a.data[1] - b.data[1]});
                 toolTipUpdate(tipItems, datapoints, positionX, positionY);
                 generateCrossLine(mouseX, mouseY, positionX, positionY);
             }
@@ -435,6 +437,7 @@ angular.module('argus.directives.charts.lineChart', [])
             function toolTipUpdate(group, datapoints, X, Y) {
                 var XOffset = 0;
                 var YOffset = 0;
+                var newXOffset = 0;
                 var OffsetMultiplier = -1;
                 var itemsPerCol = 8;
                 var circleLen = circleRadius * 2;
@@ -444,10 +447,13 @@ angular.module('argus.directives.charts.lineChart', [])
                     if (i % itemsPerCol === 0) {
                         OffsetMultiplier++;
                         YOffset = OffsetMultiplier * itemsPerCol;
+                        XOffset += newXOffset;
+                        newXOffset = 0;
                     }
 
                     // Y data point - metric specific
-                    var tempData = d3.format('.2s')(datapoints[i].data[1]);
+                    var tempData = d3.format('0,.6')(datapoints[i].data[1]);
+                        // d3.format('.2s')(datapoints[i].data[1]);
 
                     // X data point - time
                     var tempDate = new Date(datapoints[i].data[0]);
@@ -457,10 +463,10 @@ angular.module('argus.directives.charts.lineChart', [])
                     var textLine = group.select("text." + datapoints[i].graphClassName);
 
                     circle.attr('cy', 20 * (0.75 + i - YOffset) + Y)
-                        .attr('cx', X + tipOffset + tipPadding + circleRadius + XOffset * OffsetMultiplier);
+                        .attr('cx', X + tipOffset + tipPadding + circleRadius + XOffset);
                     textLine.attr('dy', 20 * (1 + i - YOffset) + Y)
-                        .attr('dx', X + tipOffset + tipPadding + circleLen + 2 + XOffset * OffsetMultiplier)
-                        .text(tempDate + " - " + tempData);
+                        .attr('dx', X + tipOffset + tipPadding + circleLen + 2 + XOffset)
+                        .text(/*tempDate + " - " +*/tempData);
 
                     /*
                      // keep this just in case different styles are needed for time and value
@@ -474,9 +480,9 @@ angular.module('argus.directives.charts.lineChart', [])
                      */
 
                     // update XOffset if existing offset is smaller than texLine
-                    var tempXOffset = textLine.node().getBBox().width + circleLen + 8;
-                    if (tempXOffset > XOffset) {
-                        XOffset = tempXOffset;
+                    var tempXOffset = textLine.node().getBBox().width + circleLen + tipOffset;
+                    if (tempXOffset > newXOffset) {
+                        newXOffset = tempXOffset;
                     }
                 }
 
@@ -552,7 +558,7 @@ angular.module('argus.directives.charts.lineChart', [])
                 var date = GMTon ? GMTformatDate(mouseX) : formatDate(mouseX);
                 focus.select('[name=crossLineTipX]')
                     .attr('x', X)
-                    .attr('y', height)
+                    .attr('y', 0)
                     .attr('dy', crossLineTipHeight)
                     .text(date);
 

--- a/ArgusWeb/app/js/directives/charts/lineChart.js
+++ b/ArgusWeb/app/js/directives/charts/lineChart.js
@@ -29,20 +29,6 @@ angular.module('argus.directives.charts.lineChart', [])
         },
         templateUrl: 'js/templates/charts/topToolbar.html',
         controller: ['$scope', function($scope) {
-
-            // set $scope values, get them from the local storage
-            $scope.menuOption = {
-                isWheelOn : false,
-                isBrushOn : true,
-                isBrushMainOn : false,
-                isTooltipOn : true,
-                isTooltipSortOn: false,
-                isTooltipDetailOn: false
-            };
-            $scope.dashboardId = $routeParams.dashboardId;
-            var menuOption = Storage.get('menuOption_' + $scope.dashboardId +'_' + lineChartIdName + $scope.lineChartId);
-            if(menuOption) $scope.menuOption = menuOption;
-
             $scope.sources = [];
             // can be used for future modal window
             $scope.noDataSeries = [];
@@ -89,6 +75,25 @@ angular.module('argus.directives.charts.lineChart', [])
             var startTime = scope.dateConfig.startTime;
             var endTime = scope.dateConfig.endTime;
             var GMTon = scope.dateConfig.gmt;
+
+            // set $scope values, get them from the local storage
+
+
+            scope.dashboardId = $routeParams.dashboardId;
+
+            var menuOption = Storage.get('menuOption_' + scope.dashboardId +'_' + lineChartIdName + scope.lineChartId);
+            if (menuOption){
+                scope.menuOption = menuOption;
+            } else {
+                scope.menuOption = {
+                    isWheelOn : false,
+                    isBrushOn : true,
+                    isBrushMainOn : false,
+                    isTooltipOn : true,
+                    isTooltipSortOn: false,
+                    isTooltipDetailOn: false
+                };
+            }
 
 
             // ---------

--- a/ArgusWeb/app/js/directives/charts/lineChart.js
+++ b/ArgusWeb/app/js/directives/charts/lineChart.js
@@ -405,16 +405,17 @@ angular.module('argus.directives.charts.lineChart', [])
                     if (metric.data.length === 0) {
                         return;
                     }
-                    //TODO: improve this logic
                     var data = metric.data;
                     var i = bisectDate(data, mouseX, 1);
                     var d0 = data[i - 1];
                     var d1 = data[i];
                     var d;
-                    if (!d0) {
+                    // snap the datapoint that lives in the x domain
+                    if (!d0 || d0[0] < x.domain()[0]) {
                         d = d1;
-                    } else if (!d1) {
+                    } else if (!d1 || d1[0] > x.domain()[1]) {
                         d = d0;
+                    // if both data points lives in the domain, choose the closer one to the mouse position
                     } else {
                         d = mouseX - d0[0] > d1[0] - mouseX ? d1 : d0;
                     }
@@ -1087,7 +1088,7 @@ angular.module('argus.directives.charts.lineChart', [])
                 graphClassNames = series.map(function(metric) { return metric.graphClassName; });
                 legendCreator(names, colors, graphClassNames);
                 // check if there is anything to graph
-                var hasNoData, emptyReturn, invalidExpression, haveThingsToGraph;
+                var hasNoData, emptyReturn, invalidExpression;
                 var tempSeries = [];
                 for (var i = 0; i < series.length; i++) {
                     if (series[i].invalidMetric) {

--- a/ArgusWeb/app/js/directives/charts/lineChart.js
+++ b/ArgusWeb/app/js/directives/charts/lineChart.js
@@ -77,22 +77,20 @@ angular.module('argus.directives.charts.lineChart', [])
             var GMTon = scope.dateConfig.gmt;
 
             // set $scope values, get them from the local storage
-
+            scope.menuOption = {
+                isWheelOn : false,
+                isBrushOn : true,
+                isBrushMainOn : false,
+                isTooltipOn : true,
+                isTooltipSortOn: false,
+                isTooltipDetailOn: false
+            };
 
             scope.dashboardId = $routeParams.dashboardId;
 
             var menuOption = Storage.get('menuOption_' + scope.dashboardId +'_' + lineChartIdName + scope.lineChartId);
             if (menuOption){
                 scope.menuOption = menuOption;
-            } else {
-                scope.menuOption = {
-                    isWheelOn : false,
-                    isBrushOn : true,
-                    isBrushMainOn : false,
-                    isTooltipOn : true,
-                    isTooltipSortOn: false,
-                    isTooltipDetailOn: false
-                };
             }
 
 
@@ -418,7 +416,7 @@ angular.module('argus.directives.charts.lineChart', [])
                     // snap the datapoint that lives in the x domain
                     if (!d0 || d0[0] < x.domain()[0]) {
                         d = d1;
-                    } else if (!d1 || d1[0] > x.domain()[1]) {
+                    } else if (!d1 || d1[0] > x.domain()[0]) {
                         d = d0;
                     // if both data points lives in the domain, choose the closer one to the mouse position
                     } else {
@@ -456,10 +454,13 @@ angular.module('argus.directives.charts.lineChart', [])
                 var YOffset = 0;
                 var newXOffset = 0;
                 var OffsetMultiplier = -1;
-                var circleLen = circleRadius * 2;
                 var itemsPerCol = 8;
-                if (datapoints.length < 2*itemsPerCol || scope.menuOption.isTooltipDetailOn)
-                    itemsPerCol = Math.ceil(datapoints.length/2);
+                var circleLen = circleRadius * 2;
+                if (scope.menuOption.isTooltipDetailOn) {
+                    itemsPerCol = 14;
+                } else if (datapoints.length < 2*itemsPerCol) {
+                    itemsPerCol = Math.ceil(datapoints.length / 2);
+                }
 
                 for (var i = 0; i < datapoints.length; i++) {
                     // create a new col after every itemsPerCol

--- a/ArgusWeb/app/js/templates/charts/topToolbar.html
+++ b/ArgusWeb/app/js/templates/charts/topToolbar.html
@@ -7,7 +7,7 @@
 			ng-mouseleave="hover = false">
 
 			<ul style="padding-left:0;">
-			<li ng-repeat="source in sources | orderBy:'name' track by $index">
+			<li ng-repeat="source in sources track by $index">
 				<span class="glyphicon glyphicon-minus" ng-style="{color: labelTextColor(source)}"></span>
 				<a ng-click="toggleSource(source)" title="Hide">{{source.name}}</a> &nbsp;
 				<a class="eyeIcon open" ng-click="hideOtherSources(source)" title="Hide all other(s)" ng-show="source.displaying"></a>
@@ -45,16 +45,20 @@
 					<label for="toggle-brush-{{chartConfig.chartId}}" title="Toggle display of timeline graph">Display timeline</label>
 				</li>
 				<li>
-					<input type="checkbox" name="toggle-tooltip" id="toggle-tooltip-{{chartConfig.chartId}}" ng-model="menuOption.isTooltipOn" />
+					<input type="checkbox" name="toggle-tooltip" id="toggle-tooltip-{{chartConfig.chartId}}" class="pointer" ng-model="menuOption.isTooltipOn" />
 					<label for="toggle-tooltip-{{chartConfig.chartId}}" title="Toggle tooltip on mouseover">Display tooltips</label>
 				</li>
 				<li>
-					<input type="checkbox" name="toggle-brush-main" id="toggle-brush-main-{{chartConfig.chartId}}" ng-model="menuOption.isBrushMainOn" />
+					<input type="checkbox" name="toggle-brush-main" id="toggle-brush-main-{{chartConfig.chartId}}" class="pointer" ng-model="menuOption.isBrushMainOn" />
 					<label for="toggle-brush-main-{{chartConfig.chartId}}" title="Enable brush selection on main chart">Enable brushing</label>
 				</li>
 				<li>
 					<input type="checkbox" name="toggle-wheel" id="toggle-wheel-{{chartConfig.chartId}}" class="pointer" ng-model="menuOption.isWheelOn" />
 					<label for="toggle-wheel-{{chartConfig.chartId}}" title="Toggle mouse wheel to zoom">Mouse zooming</label>
+				</li>
+				<li>
+					<input type="checkbox" name="tooltip-sort" id="tooltip-sort-{{chartConfig.chartId}}" class="pointer" ng-model="menuOption.isTooltipSortOn" ng-disabled="!menuOption.isTooltipOn"/>
+					<label for="tooltip-sort-{{chartConfig.chartId}}" title="Sort tooltip items by value">Tooltip Sort</label>
 				</li>
 				</ul>
 			</div>

--- a/ArgusWeb/app/js/templates/charts/topToolbar.html
+++ b/ArgusWeb/app/js/templates/charts/topToolbar.html
@@ -60,6 +60,10 @@
 					<input type="checkbox" name="tooltip-sort" id="tooltip-sort-{{chartConfig.chartId}}" class="pointer" ng-model="menuOption.isTooltipSortOn" ng-disabled="!menuOption.isTooltipOn"/>
 					<label for="tooltip-sort-{{chartConfig.chartId}}" title="Sort tooltip items by value">Tooltip Sort</label>
 				</li>
+				<li>
+					<input type="checkbox" name="tooltip-detail" id="tooltip-detail-{{chartConfig.chartId}}" class="pointer" ng-model="menuOption.isTooltipDetailOn" ng-disabled="!menuOption.isTooltipOn"/>
+					<label for="tooltip-detail-{{chartConfig.chartId}}" title="Show all the information on tooltip">Tooltip Detail</label>
+				</li>
 				</ul>
 			</div>
 

--- a/ArgusWeb/app/js/templates/charts/topToolbar.html
+++ b/ArgusWeb/app/js/templates/charts/topToolbar.html
@@ -7,7 +7,7 @@
 			ng-mouseleave="hover = false">
 
 			<ul style="padding-left:0;">
-			<li ng-repeat="source in sources track by $index">
+			<li ng-repeat="source in sources | orderBy:'name' track by $index">
 				<span class="glyphicon glyphicon-minus" ng-style="{color: labelTextColor(source)}"></span>
 				<a ng-click="toggleSource(source)" title="Hide">{{source.name}}</a> &nbsp;
 				<a class="eyeIcon open" ng-click="hideOtherSources(source)" title="Hide all other(s)" ng-show="source.displaying"></a>


### PR DESCRIPTION
1. Fix the issue of mouseover circles placed outside of the container.
2. Move x-axis tag (time) to the top of the graph.
3. Sort sources in legend alphabetically.
<img width="607" alt="screen shot 2016-12-06 at 4 11 55 pm" src="https://cloud.githubusercontent.com/assets/6592110/20951314/e999ab8a-bbd9-11e6-8b29-888887a5b091.png">

4. Remove time value in the tooltip.
5. Add sorting by value feature for tooltip items.
<img width="476" alt="screen shot 2016-12-06 at 4 12 09 pm" src="https://cloud.githubusercontent.com/assets/6592110/20951333/fb41b990-bbd9-11e6-9747-c1f585226aec.png">

6. Add detail tooltip option, which displays source names and more precision for data values.
<img width="1345" alt="screen shot 2016-12-06 at 4 11 23 pm" src="https://cloud.githubusercontent.com/assets/6592110/20951337/01823aa0-bbda-11e6-9b56-3b86a7e79f4f.png">

