### PR TITLE
Issue #336 - HoltWintersAnalysis always uses US locale

### DIFF
--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/metric/transform/HoltWintersAnalysis.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/metric/transform/HoltWintersAnalysis.java
@@ -33,8 +33,10 @@ package com.salesforce.dva.argus.service.metric.transform;
 
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
+import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -48,14 +50,19 @@ public class HoltWintersAnalysis {
     //~ Static fields/initializers *******************************************************************************************************************
 
     protected static final long ONE_WEEK_IN_MILLIS = 7 * 24 * 60 * 60 * 100;
+    protected static final NumberFormat DECIMAL_FORMAT = getDecimalFormat();
+
+    private static NumberFormat getDecimalFormat() {
+        DecimalFormat df = (DecimalFormat) NumberFormat.getInstance(Locale.US);
+        df.applyPattern("#.#####");
+        df.setRoundingMode(RoundingMode.CEILING);
+        return df;
+    }
 
     //~ Methods **************************************************************************************************************************************
 
     HoltWintersData _performHoltWintersAnalysis(Map<Long, String> bootstrappedDps, double alpha, double beta, double gamma, int seasonLength,
         long startTimestamp) {
-        DecimalFormat df = new DecimalFormat("#.#####");
-
-        df.setRoundingMode(RoundingMode.CEILING);
 
         List<Double> intercepts = new ArrayList<Double>();
         List<Double> slopes = new ArrayList<Double>();
@@ -103,10 +110,8 @@ public class HoltWintersAnalysis {
             seasonals.add(seasonal);
             deviations.add(deviation);
             if (timestamp >= startTimestamp) {
-                // forecastedDatapoints.put(timestamp, String.format("%.6g", prediction));
-                // deviationDatapoints.put(timestamp, String.format("%.6g", deviation));
-                forecastedDatapoints.put(timestamp, df.format(prediction));
-                deviationDatapoints.put(timestamp, df.format(deviation));
+                forecastedDatapoints.put(timestamp, DECIMAL_FORMAT.format(prediction));
+                deviationDatapoints.put(timestamp, DECIMAL_FORMAT.format(deviation));
             }
             i++;
         }

--- a/ArgusCore/src/test/java/com/salesforce/dva/argus/service/metric/transform/HoltWintersTransformTest.java
+++ b/ArgusCore/src/test/java/com/salesforce/dva/argus/service/metric/transform/HoltWintersTransformTest.java
@@ -71,7 +71,7 @@ public class HoltWintersTransformTest {
         Map<Long, String> forecastedDatapoints = holtWinters._performHoltWintersAnalysis(dp, alpha, beta, gamma, seasonLength, 2L)
             .getForecastedDatapoints();
 
-        assertTrue(forecastedDatapoints.equals(expected));
+        assertEquals(expected, forecastedDatapoints);
     }
 
     @Test
@@ -106,7 +106,7 @@ public class HoltWintersTransformTest {
         Map<Long, String> deviationDatapoints = holtWinters._performHoltWintersAnalysis(dp, alpha, beta, gamma, seasonLength, 2L)
             .getDeviationDatapoints();
 
-        assertTrue(deviationDatapoints.equals(expected));
+        assertEquals(expected, deviationDatapoints);
     }
 }
 /* Copyright (c) 2016, Salesforce.com, Inc.  All rights reserved. */


### PR DESCRIPTION
I could see two ways to solve #336 , but I wasn't sure which one would work better with the rest of the system.

1. (the one implemented in this branch).  The HoltWintersTransform always uses US locale for its outupt
2. HoltWintersTransform uses the same locale and format for parsing its input data and returning its output data.

Which do you think is better?  I think I like number 2, but I was afraid that other parts of the system might be assuming the output was in US locale.