### PR TITLE
Fix endless loading spinner when graph is empty issue

### DIFF
--- a/ArgusWeb/app/js/directives/charts/lineChart.js
+++ b/ArgusWeb/app/js/directives/charts/lineChart.js
@@ -824,7 +824,6 @@ angular.module('argus.directives.charts.lineChart', [])
 
 
             function updateGraph(series) {
-                scope.graphRendered = false;
                 var allDatapoints = [];
                 currSeries = series;
 
@@ -856,7 +855,6 @@ angular.module('argus.directives.charts.lineChart', [])
 
                 // draw flag(s) to denote annotation mark
                 updateAnnotations();
-                scope.graphRendered = true;
             }
 
             // when there is no data for series, display a message

--- a/ArgusWeb/app/js/templates/charts/topToolbar.html
+++ b/ArgusWeb/app/js/templates/charts/topToolbar.html
@@ -66,6 +66,5 @@
 
 		<div class="toolbarItem right dateRange" id="date-range-{{chartConfig.chartId}}">{{dateRange}}</div>
 	</div>
-	<div ng-loading="graphRendered"></div>
 </div>
 


### PR DESCRIPTION
The problem is caused by return before setting graphRendered to true. But I will delete it right now because it is not working when the chart is being rendered. The spinner will just stop spinning anyway. Example: http://localhost:8080/argus/#/dashboards/464709?

I guess d3 might send some callback to get every pixel rendered on page. Therefore, setting graphRendered to true it after some d3 call makes no sense.

Will work on optimizing the datapoints rendering instead to make the render time neglectable.