### PR TITLE
Allow overriding of jpa properties by using system.property.jpa prefix

### DIFF
--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/system/SystemInitializer.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/system/SystemInitializer.java
@@ -74,6 +74,7 @@ import java.util.Properties;
  * @author  Tom Valine (tvaline@salesforce.com), Bhinav Sura (bhinav.sura@salesforce.com)
  */
 final class SystemInitializer extends AbstractModule {
+    private static final String JPA_PROPERTY_PREFIX = "system.property.jpa";
 
     //~ Instance fields ******************************************************************************************************************************
 
@@ -175,7 +176,22 @@ final class SystemInitializer extends AbstractModule {
     }
 
     private void configurePersistence() {
-        binder().install(new JpaPersistModule("argus-pu"));
+        JpaPersistModule jpaPersistModule = new JpaPersistModule("argus-pu");
+        jpaPersistModule.properties(getJpaProperties(_systemConfiguration));
+        binder().install(jpaPersistModule);
+    }
+
+    private Properties getJpaProperties(Properties properties) {
+        Properties jpaProperties = new Properties();
+        for (Object rawPropertyNameWithPrefix : properties.keySet()) {
+            String propertyNameWithPrefix = (String) rawPropertyNameWithPrefix;
+            if (propertyNameWithPrefix.startsWith(JPA_PROPERTY_PREFIX)) {
+                String propertyName = propertyNameWithPrefix.substring(JPA_PROPERTY_PREFIX.length());
+                Object propertyValue = properties.get(rawPropertyNameWithPrefix);
+                jpaProperties.put(propertyName, propertyValue);
+            }
+        }
+        return jpaProperties;
     }
 
     private void configureLogging() {

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/system/SystemInitializer.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/system/SystemInitializer.java
@@ -74,7 +74,7 @@ import java.util.Properties;
  * @author  Tom Valine (tvaline@salesforce.com), Bhinav Sura (bhinav.sura@salesforce.com)
  */
 final class SystemInitializer extends AbstractModule {
-    private static final String JPA_PROPERTY_PREFIX = "system.property.jpa";
+    private static final String JPA_PROPERTY_PREFIX = "system.property.jpa.";
 
     //~ Instance fields ******************************************************************************************************************************
 
@@ -177,7 +177,8 @@ final class SystemInitializer extends AbstractModule {
 
     private void configurePersistence() {
         JpaPersistModule jpaPersistModule = new JpaPersistModule("argus-pu");
-        jpaPersistModule.properties(getJpaProperties(_systemConfiguration));
+        Properties jpaProperties = getJpaProperties(_systemConfiguration);
+        jpaPersistModule.properties(jpaProperties);
         binder().install(jpaPersistModule);
     }
 


### PR DESCRIPTION
Issue #342 : This should allow us to use the same built war in multiple environments by specifying the database connection properties at runtime.