### PR TITLE
Temporary fix for the date range issue

### DIFF
--- a/ArgusWeb/app/js/directives/charts/lineChart.js
+++ b/ArgusWeb/app/js/directives/charts/lineChart.js
@@ -959,7 +959,8 @@ angular.module('argus.directives.charts.lineChart', [])
                 if(!startTime) startTime = dateExtent[0]; //startTime/endTime will not be 0
                 if(!endTime) endTime = dateExtent[1];
 
-                x.domain([startTime, endTime]);
+                //x.domain([startTime, endTime]);
+                x.domain(dateExtent); //doing this cause some date range are defined in metric queries and regardless of ag-date
 
                 var yDomain = d3.extent(allDatapoints, function (d) {
                     return d[1];


### PR DESCRIPTION
For some dashboard, the metric embedded in the markup should define the time range rather than the ag-date. So just use the response data's date range right now for a quick solution.