### PR TITLE
update argus-core pom.xml

### DIFF
--- a/ArgusCore/pom.xml
+++ b/ArgusCore/pom.xml
@@ -382,9 +382,27 @@
             <version>3.6.14</version>
         </dependency>
         <dependency>
-        <groupId>org.apache.phoenix</groupId>
-        <artifactId>phoenix-core</artifactId>
-        <version>4.9.0-HBase-0.98</version>
+            <groupId>org.apache.phoenix</groupId>
+            <artifactId>phoenix-core</artifactId>
+            <version>4.9.0-HBase-0.98</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>jersey-core</artifactId>
+                    <groupId>com.sun.jersey</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jersey-json</artifactId>
+                    <groupId>com.sun.jersey</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jersey-client</artifactId>
+                    <groupId>com.sun.jersey</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jersey-server</artifactId>
+                    <groupId>com.sun.jersey</groupId>
+                </exclusion>
+            </exclusions>
       </dependency>
     </dependencies>
     <dependencyManagement>


### PR DESCRIPTION
exclude jersey based dependencies from phoenix dependency.