### PR TITLE
updates for chart options

### DIFF
--- a/ArgusWeb/app/css/main.css
+++ b/ArgusWeb/app/css/main.css
@@ -37,7 +37,7 @@ input:-moz-placeholder {color:#BBB;}
 ul {margin-bottom:0;}
 ul li {list-style:none;}
 
-button[disabled] {color:#CCC;}
+button[disabled], .disabled {color:#CCC !important;}
 
 .floatL {float:left;}
 .floatR {float:right;}
@@ -115,9 +115,7 @@ h5.bcDesc {margin-bottom:20px; font-weight:normal;}
 .modal-backdrop.fade {opacity:0;}
 .modal-backdrop, .modal-backdrop.fade.in {}
 .modal .smallClose {position:absolute; display:inline-block; top:10px; right:1em;}
-
 .modal .chkBox {margin:.75em .5em 0 0; max-width:90%; vertical-align:top;}
-
 .modal .footer {margin-top:1em; padding-top:1em; border-top:solid 1px #CCC;}
 
 /* lighten up default modal backdrop (mask) */

--- a/ArgusWeb/app/css/main.css
+++ b/ArgusWeb/app/css/main.css
@@ -114,10 +114,9 @@ h5.bcDesc {margin-bottom:20px; font-weight:normal;}
 .modal-backdrop {position:fixed; top:0; right:0; bottom:0; left:0; z-index:999; background-color:#000;}
 .modal-backdrop.fade {opacity:0;}
 .modal-backdrop, .modal-backdrop.fade.in {}
-.modal .smallClose {position:absolute; display:inline-block; top:1em; right:1em;}
+.modal .smallClose {position:absolute; display:inline-block; top:10px; right:1em;}
 
 .modal .chkBox {margin:.75em .5em 0 0; max-width:90%; vertical-align:top;}
-.modal .chkBoxLbl {max-width:90%;}
 
 .modal .footer {margin-top:1em; padding-top:1em; border-top:solid 1px #CCC;}
 
@@ -128,13 +127,13 @@ h5.bcDesc {margin-bottom:20px; font-weight:normal;}
 
 
 /* chart options */
-.modal .mainContent {padding:0 1em 1em 1em;}
+.modal .mainContent {padding:1em 0;}
 .modal .mainContent .title {margin-bottom:.5em; padding-bottom:.25em; border-bottom:solid 1px #CCC;}
 .modal .mainContent h2 {margin-left:0; padding-top:0; font-size:1.5em;}
 .modal .mainContent h3 {font-size:1.3em;}
-.modal .mainContent h4.sectionTitle {font-weight:normal; color:#428BCA;}
+.modal .mainContent h4.sectionTitle {margin-top:1em; padding:.25em; background-color:#EEE; font-weight:normal; color:#428BCA;}
 .modal .mainContent pre {overflow-x:auto; margin-top:1em;}
-.modal .mainContent label {color:#666;}
+.modal .mainContent label {max-width:90%; font-weight:normal; color:#666;}
 
 
 /* Dashboard related **/

--- a/ArgusWeb/app/js/directives/charts/lineChart.js
+++ b/ArgusWeb/app/js/directives/charts/lineChart.js
@@ -90,60 +90,42 @@ angular.module('argus.directives.charts.lineChart', [])
                     // controller: chartOptions,     // ['optionsModal', 'menuOption', ChartOptions],
                     // controllerAs: 'ChartOptions',     // modal options
                     controller: ['$scope', function($scope) {
-                        // console.log( $scope );
-                        // console.log( chartId );
-                        // console.log( chartTitle );
 
-                        // set $scope items
+                        // set $scope items from $resolve method above - only way to 'watch' $scope for changes in chart options.
                         $scope.menuOption = $scope.$resolve.menuOption;
+                        
                         $scope.chartId = chartId;
                         $scope.chartTitle = chartTitle;
 
                         // display current date in 'sample' format
                         var currDate = new Date();
-                        var sampleFormat = "%a %b %e %Y %H:%M"; // "Sat Nov 5 1929 11:58"
-                        // var formatDate = d3.timeFormat(sampleFormat);
+                        var sampleFormat = "%-m/%-d/%y %H:%M:%S"; // "Sat Nov 5 1929 11:58"
+                        
                         $scope.dateFormatOutput = d3.timeFormat(sampleFormat)(currDate);
 
                         // update date format to show sample date in modal view
                         $scope.updateDateFormatOutput = function() {
-                            // check if field is empty
-                            if (!$scope.menuOption.dateFormat || $scope.menuOption.length === 0) {
-                                $scope.dateFormatOutput = d3.timeFormat(sampleFormat)(new Date());
-                            } else {
-                                // update new date displayed with format in field
-                                // check for a valid date format ?
-                                $scope.dateFormatOutput = d3.timeFormat($scope.menuOption.dateFormat)(new Date());
-                            }
+                            var userInputDateFormat = $scope.menuOption.dateFormat ? $scope.menuOption.dateFormat : sampleFormat;
+                            $scope.dateFormatOutput = d3.timeFormat(userInputDateFormat)(new Date());
                         }
 
-                        /*
-                        $scope.menuOption.isBrushMainOn = true;
-                        $scope.menuOption.isWheelOn = true;
-                        $scope.menuOption.isTooltipSortOn = true;
-                        $scope.menuOption.isTooltipDetailOn = true;
-                        $scope.menuOption.downSampleMethod = 'mode-median';        // 'largest-triangle-one-bucket'
-                        */
+                        // display date in correct format when modal opens: either menuOptions OR current date with 'sampleFormat'
+                        $scope.updateDateFormatOutput();
 
                         $scope.close = function () {
                             optionsModal.close();
                         };
 
-                        //add lightMask class when modal is opened
+                        // add lightMask class when modal is opened
                         optionsModal.opened.then(function () {
                             $('body').addClass('lightMask');
                         });
 
-                        //remove lightMask class when modal is closed
+                        // remove lightMask class when modal is closed
                         optionsModal.result.then(function (menuOption) {
-                            // angular.noop();
-                            // $scope.menuOption = menuOption;
-                            // console.log( $scope.menuOption );
-
+                            angular.noop();
                         }, function (menuOption) {
                             $('body').removeClass('lightMask');
-
-                            // console.log( $scope.menuOption );
                         });
                     }]
                 });
@@ -222,28 +204,53 @@ angular.module('argus.directives.charts.lineChart', [])
             if (isNaN(agYMin)) agYMin = undefined;
             if (isNaN(agYMax)) agYMax = undefined;
 
-            // set $scope values, get them from the local storage
-            scope.menuOption = {
-                isWheelOn : false,
-                isBrushOn : !chartOptions.smallChart,
-                isBrushMainOn : false,
-                isTooltipOn : true,
-                isTooltipSortOn: false,
-                isTooltipDetailOn: false,
-                isSyncChart: false,
-                downSampleMethod: 'largest-triangle-one-bucket'
-            };
-            scope.hideMenu = false;
+            // date formats: https://github.com/d3/d3-time-format/blob/master/README.md#timeFormat
+            var longDate = '%A, %b %e, %H:%M';      // Saturday, Nov 5, 11:58
+            var shortDate = '%b %e, %H:%M';
+            var numericalDate = '%-m/%-d/%y %H:%M:%S';
+            var smallChartDate = '%x';  // %x = %m/%d/%Y  11/5/2016
 
+            // default formats & settings for chart options
+            var defaultFormat = ',';
+            var defaultYaxis = '.3s';
+            var defaultTicksYaxis = '5';
+
+            scope.hideMenu = false;
             scope.dashboardId = $routeParams.dashboardId;
 
             var menuOption = Storage.get('menuOption_' + scope.dashboardId + '_' + chartId);
-            if (menuOption){
-                scope.menuOption = menuOption;
-            }
+            
+            // set scope values, get them from the local storage before setting default
+            scope.menuOption = {
+                dateFormat: (menuOption && menuOption.dateFormat) ? menuOption.dateFormat : numericalDate,  // check for smallChart, then localStorage before setting default
+
+                formatYaxis: (menuOption && menuOption.formatYaxis) ? menuOption.formatYaxis : defaultYaxis,
+                numTicksYaxis: (menuOption && menuOption.numTicksYaxis) ? menuOption.numTicksYaxis : defaultTicksYaxis,
+
+                leadingNum: (menuOption && menuOption.leadingNum) ? menuOption.leadingNum : null,
+                trailingNum: (menuOption && menuOption.trailingNum) ? menuOption.trailingNum : null,
+
+                downSampleMethod: (menuOption && menuOption.downSampleMethod) ? menuOption.downSampleMethod : '',
+                isBrushMainOn: false,
+                isWheelOn: false,
+                isBrushOn: !chartOptions.smallChart,    // for 'smallChart' only, does not display timeline brush below graph
+
+                isTooltipDetailOn: false,   // to be replaced by other settings below:
+                // rawTooltip: ,
+                // customTooltipFormat: ,
+                // decimalNumTooltip: ,
+                
+                isTooltipOn: true,   // to be removed. most users dont want to turn tooltips off
+                isTooltipSortOn: true,
+
+                // colorPallete: 
+            };
+
+            console.log( scope.menuOption );
+            // -------------
+
 
             var dateExtent; //extent of non empty data date range
-            // ---------
             var topToolbar = $(element); //jquery selection
             var container = topToolbar.parent()[0];//real DOM
 
@@ -258,6 +265,7 @@ angular.module('argus.directives.charts.lineChart', [])
                 containerHeight = chartOptions.chart.height === undefined ? containerHeight: chartOptions.chart.height;
                 containerWidth = chartOptions.chart.width === undefined ? containerWidth: chartOptions.chart.width;
             }
+
             var xAxisLabelHeightFactor = 15;
             var brushHeightFactor = 20;
             var mainChartRatio = 0.8, //ratio of height
@@ -297,29 +305,19 @@ angular.module('argus.directives.charts.lineChart', [])
 
             var bufferRatio = 0.2; //the ratio of buffer above/below max/min on yAxis for better showing experience
 
-            // Local helpers
-            // date formats
-            // https://github.com/d3/d3-time-format/blob/master/README.md#timeFormat
-            var longDate = '%A, %b %e, %H:%M';      // Saturday, Nov 5, 11:58
-            var shortDate = '%b %e, %H:%M';
-            var numericalDate = '%-m/%-d/%y %H:%M:%S';
-            var smallChartDate = '%x';  // %x = %m/%d/%Y  11/5/2016
-
             var bisectDate = d3.bisector(function (d) {
                 return d[0];
             }).left;
-
-            // date settings
-            var formatDate = chartOptions.smallChart ? d3.timeFormat(smallChartDate) : d3.timeFormat(shortDate);
-            var GMTformatDate = chartOptions.smallChart ? d3.utcFormat(smallChartDate) : d3.utcFormat(numericalDate);
-
-            // not utilized ?
-            var formatValue = d3.format(',');
+            
+            // date settings.  tmpDate is default is chart option 'dateFormat' is not set.
+            var tmpDate = scope.menuOption.dateFormat ? scope.menuOption.dateFormat : numericalDate;
+            var formatDate = chartOptions.smallChart ? d3.timeFormat(smallChartDate) : d3.timeFormat(tmpDate);
+            var GMTformatDate = chartOptions.smallChart ? d3.utcFormat(smallChartDate) : d3.utcFormat(tmpDate);
 
             //graph setup variables
             var x, x2, y, y2,
                 nGridX = chartOptions.smallChart ? 3 : 7,
-                nGridY = chartOptions.smallChart ? 3 : 5,
+                nGridY = chartOptions.smallChart ? 3 : scope.menuOption.numTicksYaxis,
                 xAxis, xAxis2, yAxis, yAxisR, xGrid, yGrid,
                 line, line2, area, area2,
                 brush, brushMain, zoom,
@@ -368,13 +366,13 @@ angular.module('argus.directives.charts.lineChart', [])
                 yAxis = d3.axisLeft()
                     .scale(y)
                     .ticks(nGridY)
-                    .tickFormat(d3.format('.3s'))
+                    .tickFormat(d3.format(scope.menuOption.formatYaxis))
                 ;
 
                 yAxisR = d3.axisRight()
                     .scale(y)
                     .ticks(nGridY)
-                    .tickFormat(d3.format('.3s'))
+                    .tickFormat(d3.format(scope.menuOption.formatYaxis))
                 ;
 
                 //grid
@@ -769,7 +767,8 @@ angular.module('argus.directives.charts.lineChart', [])
                                         .attr('dx', X + tipOffset + tipPadding + circleLen + 2 + XOffset);
 
                     if (scope.menuOption.isTooltipDetailOn) {
-                        textLine.text(datapoints[i].name + "  -  " + d3.format('0,.8')(tempData));
+                        var name = trimMetricName(datapoints[i].name);
+                        textLine.text(name + "  -  " + d3.format('0,.8')(tempData));
                     } else {
                         textLine.text(d3.format('.3s')(tempData));
                     }
@@ -817,12 +816,29 @@ angular.module('argus.directives.charts.lineChart', [])
                 tipBox.attr('transform', transformAttr);
             }
 
+            // TODO: move to filter
+            function trimMetricName(metricName) {
+                if (!metricName) return;
+                
+                var startVal, endVal;
+                startVal = (scope.menuOption.leadingNum > 0) ? scope.menuOption.leadingNum : null;
+                endVal = (scope.menuOption.trailingNum > 0) ? scope.menuOption.trailingNum : null;
+
+                if (startVal && !endVal) {
+                    return metricName.slice(startVal);
+                } else if (endVal) {
+                    return metricName.slice(startVal, -endVal);
+                } else {
+                    return metricName;
+                }
+            }
+
             function legendCreator(names, colors, graphClassNames) {
                 var tmpSources = [];
                 for (var i = 0; i < names.length; i++) {
                     var tempColor = colors[i] === null ? z(names[i]) : colors[i];
                     tmpSources.push({
-                        name: names[i],
+                        name: trimMetricName(names[i]),
                         displaying: true,
                         color: tempColor,
                         graphClassName: graphClassNames[i]
@@ -870,7 +886,7 @@ angular.module('argus.directives.charts.lineChart', [])
                 if(isNaN(mouseY)){ //mouseY can be 0
                     textY = "No Data";
                 }else{
-                    textY = d3.format('.3s')(mouseY);
+                    textY = d3.format(scope.menuOption.formatYaxis)(mouseY);
                 }
 
                 focus.select('[name=crossLineTipY')
@@ -1340,8 +1356,6 @@ angular.module('argus.directives.charts.lineChart', [])
                 }
             }
 
-            // menuOption items
-
             //toggle time brush
             function toggleBrush() {
                 var display = !scope.menuOption.isBrushOn ? 'none' : null;
@@ -1385,30 +1399,22 @@ angular.module('argus.directives.charts.lineChart', [])
                 updateStorage();
             }
 
-            // end menuOption items
-
             //date range
             function updateDateRange() {
-                var start, end, str, userInputDateFormat;
-
-                // user input dateFormat from chart options
-                if (scope.menuOption.dateFormat) {
-                    // check if isValid date?
-                    userInputDateFormat = scope.menuOption.dateFormat;
-                } else {
-                    userInputDateFormat = shortDate;
-                    userInputDateFormat = numericalDate;
-                }
+                var start, end, str, 
+                    dateFormat = scope.menuOption.dateFormat;
 
                 // date settings
                 if (GMTon) {
-                    GMTformatDate = chartOptions.smallChart ? d3.utcFormat(smallChartDate) : d3.utcFormat(userInputDateFormat);
+                    var dateFormatGMT = dateFormat ? dateFormat : numericalDate;
+                    GMTformatDate = chartOptions.smallChart ? d3.utcFormat(smallChartDate) : d3.utcFormat(dateFormatGMT);
 
                     start = GMTformatDate(x.domain()[0]);
                     end = GMTformatDate(x.domain()[1]);
                     str = start + ' - ' + end + " (GMT/UTC)";
                 } else {
-                    formatDate = chartOptions.smallChart ? d3.timeFormat(smallChartDate) : d3.timeFormat(userInputDateFormat);
+                    dateFormat = dateFormat ? dateFormat : shorDate;
+                    formatDate = chartOptions.smallChart ? d3.timeFormat(smallChartDate) : d3.timeFormat(formatDate);
 
                     start = formatDate(x.domain()[0]);
                     end = formatDate(x.domain()[1]);
@@ -1494,7 +1500,7 @@ angular.module('argus.directives.charts.lineChart', [])
                 $('[name=oneMonth]', topToolbar).click(brushMinute(60*24*30));
                 $('[name=oneYear]', topToolbar).click(brushMinute(60*24*365));
 
-                //toggle
+                // TODO: to be remove once chart options is in place
                 $('[name=toggle-brush]', topToolbar).change(toggleBrush);
                 $('[name=toggle-brush-main]', topToolbar).change(toggleBrushMain);
                 $('[name=toggle-wheel]', topToolbar).change(toggleWheel);
@@ -1518,6 +1524,8 @@ angular.module('argus.directives.charts.lineChart', [])
             };
 
             function downSample(series){
+                if (!series) return;
+
                 // Create the sampler
                 var temp = JSON.parse(JSON.stringify(series));
                 var sampler;
@@ -1570,17 +1578,19 @@ angular.module('argus.directives.charts.lineChart', [])
                 }
 
                 // Run the sampler
-                series.forEach(function(metric, index){
-                    //determine whether to downsample or not
-                    //downsample if there are too many datapoints per pixel
-                    if(metric.data.length / containerWidth > downsampleThreshold){
-                        //determine bucket size
-                        var bucketSize = Math.ceil(metric.data.length / (downsampleThreshold * containerWidth));
-                        // Configure the size of the buckets used to downsample the data.
-                        sampler.bucketSize(bucketSize);
-                        temp[index].data  = sampler(metric.data);
-                    }
-                });
+                if (sampler) {
+                    series.forEach(function(metric, index){
+                        //determine whether to downsample or not
+                        //downsample if there are too many datapoints per pixel
+                        if(metric.data.length / containerWidth > downsampleThreshold){
+                            //determine bucket size
+                            var bucketSize = Math.ceil(metric.data.length / (downsampleThreshold * containerWidth));
+                            // Configure the size of the buckets used to downsample the data.
+                            sampler.bucketSize(bucketSize);
+                            temp[index].data  = sampler(metric.data);
+                        }
+                    });
+                }
 
                 return temp;
             }
@@ -1656,9 +1666,26 @@ angular.module('argus.directives.charts.lineChart', [])
                 toggleBrushMain();
                 toggleWheel();
                 toggleTooltip();
+                legendCreator(names, colors, graphClassNames);
+                scope.updateDownSample();
 
+                // update any changes for the Y-axis tick formatting & number of ticks displayed
+                yAxis = d3.axisLeft()
+                    .scale(y)
+                    .ticks(scope.menuOption.numTicksYaxis)
+                    .tickFormat(d3.format(scope.menuOption.formatYaxis))
+                ;
+
+                yGrid = d3.axisLeft()
+                    .scale(y)
+                    .ticks(scope.menuOption.numTicksYaxis)
+                    .tickSizeInner(-width)
+                ;
+
+                yAxisG.call(yAxis);
+                yGridG.call(yGrid);
+                
                 // mouseMove();
-                // downSample();
             }, true);
 
             //TODO improve the resize efficiency if performance becomes an issue

--- a/ArgusWeb/app/js/directives/charts/lineChart.js
+++ b/ArgusWeb/app/js/directives/charts/lineChart.js
@@ -255,6 +255,9 @@ angular.module('argus.directives.charts.lineChart', [])
                 customTooltipFormat: (menuOption && menuOption.customTooltipFormat) ? menuOption.customTooltipFormat : sampleCustomFormat,
 
                 colorPallete: (menuOption && menuOption.colorPallete) ? menuOption.colorPallete : d3.schemeCategory20,
+
+                // TODO: refactor code base for no 'isTooltipOn' property
+                isTooltipOn: true
             };
 
             var dateExtent; //extent of non empty data date range

--- a/ArgusWeb/app/js/templates/modals/chartOptions.html
+++ b/ArgusWeb/app/js/templates/modals/chartOptions.html
@@ -5,57 +5,62 @@
 
 	<!-- left col -->
 	<div class="col-md-6">
-
 		<h4 class="sectionTitle btmBdr">Formatting</h4>
 
-		<div style="white-space:nowrap;">
-			<label for="dateFormat-{{chartId}}">Date: </label>
+		<div style="margin:.5em 0 .5em 1em;">
+			<label for="dateFormat-{{chartId}}"><strong>Date:</strong> </label>
 			<input id="dateFormat-{{chartId}}" type="input" style="padding:0 .25em; margin-right:.5em;" placeholder="%A, %b %e, %H:%M" size="25"
 				ng-model="menuOption.dateFormat"
-				ng-blur="updateDateFormatOutput()"
+				ng-change="updateDateFormatOutput()"
 				/>
-			<a class="glyphicon glyphicon-info-sign" href="https://github.com/d3/d3-time-format" target="_blank"></a> &nbsp; 
-			<span style="color:#999;">{{dateFormatOutput}}</span>
+			<a class="glyphicon glyphicon-info-sign" href="https://github.com/d3/d3-time-format" target="_blank"></a>
+			<div style="margin-left:3em; color:#999;">{{dateFormatOutput}}</div>
 		</div>
 
-		<div style="margin-top:.5em; white-space:nowrap;">
-			<label>Tick labels:</label>&nbsp;<a class="glyphicon glyphicon-info-sign" href="https://github.com/d3/d3-format/blob/master/README.md#format" target="_blank"></a>
+		<div style="margin:.5em 0 .5em 1em;">
+			<label><strong>Tick labels:</strong>&nbsp;</label>&nbsp;<a class="glyphicon glyphicon-info-sign" href="https://github.com/d3/d3-format/blob/master/README.md#format" target="_blank"></a>
 
-			<div style="margin:0 0 .5em 1em;">
-			<label for="tickFormat-Yaxis-{{chartId}}">Y-axis: </label>
-			<input id="tickFormat-Yaxis-{{chartId}}" type="input" style="padding:0 .25em; margin-right:.5em;" placeholder="" size="5" ng-model="menuOption.formatYaxis" />
+			<div style="margin:0 0 .5em 1em;" class="hide">
+				<label for="tickFormat-Xaxis-{{chartId}}">X-axis: </label>
+				<input id="tickFormat-Xaxis-{{chartId}}" type="input" style="padding:0 .25em; margin-right:.5em;" placeholder="" size="5" ng-model="menuOption.formatXaxis" />
 
-			<select ng-model="menuOption.numTicksYaxis" style="margin-left:.5em;">
-				<option value="">Select # of ticks</option>
-				<option value="4">4</option>
-				<option value="5">5</option>
-				<option value="6">6</option>
-				<option value="7">7</option>
-			</select>
+				<label>&nbsp; # of ticks: </label>
+				<select ng-model="menuOption.numTicksXaxis" style="margin-left:.5em;">
+					<option value="4">4</option>
+					<option value="5">5</option>
+					<option value="6">6</option>
+					<option value="7" ng-selected="true">7</option>
+				</select>
 			</div>
 
 			<div style="margin:0 0 .5em 1em;">
-			<label for="tickFormat-Xaxis-{{chartId}}">X-axis: </label>
-			<input id="tickFormat-Xaxis-{{chartId}}" type="input" style="padding:0 .25em; margin-right:.5em;" placeholder="" size="5" ng-model="menuOption.formatXaxis" />
+				<label for="tickFormat-Yaxis-{{chartId}}">Y-axis: </label>
+				<input id="tickFormat-Yaxis-{{chartId}}" type="input" style="padding:0 .25em; margin-right:.5em;" placeholder="" size="5" ng-model="menuOption.formatYaxis" />
 
-			<select ng-model="menuOption.numTicksXaxis" style="margin-left:.5em;">
-				<option value="">Select # of ticks</option>
-				<option value="4">4</option>
-				<option value="5">5</option>
-				<option value="6">6</option>
-				<option value="7">7</option>
-			</select>
+				<label>&nbsp; # of ticks: </label>
+				<select ng-model="menuOption.numTicksYaxis" style="margin-left:.5em;">
+					<option value="4" ng-selected="menuOption.numTicksYaxis == 4">4</option>
+					<option value="5" ng-selected="menuOption.numTicksYaxis == 5">5</option>
+					<option value="6" ng-selected="menuOption.numTicksYaxis == 6">6</option>
+					<option value="7" ng-selected="menuOption.numTicksYaxis == 7">7</option>
+				</select>
 			</div>
 		</div>
 
 		<h4 class="sectionTitle btmBdr">Truncate metric name</h4>
 
-		<div style="margin:0 0 .5em 1em;">
-			<label for="leadingNum-{{chartId}}">Leading 'n' number:</label> <input id="leadingNum-{{chartId}}" type="input" ng-model="menuOption.leadingNum" size="7" />
+		<div style="display:inline-block; margin:.5em 0 .5em 1em;">
+			<label for="leadingNum-{{chartId}}">Leading 'n' #:</label> &nbsp;
+			<input id="leadingNum-{{chartId}}" type="number" min="0" ng-model="menuOption.leadingNum" style="width:3.5em;" />
 		</div>
 		
-		<div style="margin:0 0 .5em 1em;">
-			<label for="trailingNum-{{chartId}}">Trailing 'n' number:</label> <input id="trailingNum-{{chartId}}" type="input" ng-model="menuOption.trailingNum" size="7" />
+		<div style="display:inline-block; margin:.5em 0 .5em 1em;">
+			<label for="trailingNum-{{chartId}}">Trailing 'n' #:</label> &nbsp;
+			<input id="trailingNum-{{chartId}}" type="number" min="0" ng-model="menuOption.trailingNum" style="width:3.5em;" />
+		</div>
+
+		<div class="hide" style="margin-left:1em;">
+			<label>output:</label>&nbsp;<span>argus.jvm:mem.nonheap.used</span>
 		</div>
 
 		<h4 class="sectionTitle btmBdr">Downsampling data <a class="glyphicon glyphicon-info-sign" href="https://github.com/d3fc/d3fc-sample" style="font-size:14px;" target="_blank"></a></h4>
@@ -64,44 +69,42 @@
 			<label>Select a downsample method: </label>&nbsp;
 			<select ng-model="menuOption.downSampleMethod" name="down-sample-method">
 				<option value="">[ Select a method ]</option>
-				<option value="largest-triangle-one-bucket" ng-selected="">Triangle 1 Bucket</option>
-				<option value="largest-triangle-three-bucket" ng-selected="">Triangle 3 Bucket</option>
-				<option value="mode-median" ng-selected="">Mode Median</option>
-				<option value="every-nth-point" ng-selected="">Every n'th point</option>
+				<option value="largest-triangle-one-bucket" ng-selected="menuOption.downSampleMethod == 'largest-triangle-one-bucket'">Triangle 1 Bucket</option>
+				<option value="largest-triangle-three-bucket" ng-selected="menuOption.downSampleMethod == 'largest-triangle-three-bucket'">Triangle 3 Bucket</option>
+				<option value="mode-median" ng-selected="menuOption.downSampleMethod == 'mode-median'">Mode Median</option>
+				<option value="every-nth-point" ng-selected="menuOption.downSampleMethod == 'every-nth-point'">Every n'th point</option>
 			</select>
 		</div>
 	</div>
 
 	<!-- right col -->
 	<div class="col-md-6">
-
 		<h4 class="sectionTitle btmBdr">Brushing & Zooming</h4>
 
 		<input class="chkBox pointer" id="toggleBrushMain-{{chartId}}" type="checkbox" ng-model="menuOption.isBrushMainOn" title="Enable brush selection on chart" />&nbsp;<label class="chkBoxLbl" for="toggleBrushMain-{{chartId}}">Enable "brushing" on the graph to create a time-range selection.</label>
 
-		<br />
-
-		<input class="chkBox pointer" id="toggle-wheel-{{chartId}}" type="checkbox" ng-model="menuOption.isWheelOn" title="Toggle mouse wheel to zoom" />&nbsp;<label class="chkBoxLbl" for="toggle-wheel-{{chartId}}">Use mousewheel to zoom in/out of the main graph. <span style="font-weight:normal;">(Move mouse off the main graph to page scroll)</span></label>
+		<br /><input class="chkBox pointer" id="toggle-wheel-{{chartId}}" type="checkbox" ng-model="menuOption.isWheelOn" title="Toggle mouse wheel to zoom" />&nbsp;
+		<label class="chkBoxLbl" for="toggle-wheel-{{chartId}}">Use mousewheel to zoom in/out of the main graph.
+		<br /><span style="font-weight:normal;">(Move mouse off the main graph to page scroll)</span></label>
 
 		<h4 class="sectionTitle btmBdr">Tooltips</h4>
 
-		<input class="chkBox pointer" id="tooltips-raw-{{chartId}}" type="checkbox" ng-model="menuOption.rawTooltip" title="Display raw data inside tooltips" />&nbsp;<label class="chkBoxLbl" for="tooltips-raw-{{chartId}}">Display raw data point value. <span style="font-weight:normal;">No formatting applied.</span></label>
+		<input class="chkBox pointer" id="tooltip-sort-{{chartId}}" name="tooltip-sort" type="checkbox" ng-model="menuOption.isTooltipSortOn" ng-click="updateStorage()" />&nbsp;<label class="chkBoxLbl" for="tooltip-sort-{{chartId}}" title="Sort tooltip items by value">Tooltip sorting</label>
+
+		<br /><input class="chkBox pointer" id="tooltips-raw-{{chartId}}" type="checkbox" ng-model="menuOption.rawTooltip" title="Display raw data inside tooltips" />&nbsp;<label class="chkBoxLbl" for="tooltips-raw-{{chartId}}">Display raw data point value. <span style="font-weight:normal;">No formatting applied.</span></label>
 
 		<br /><label class="chkBoxLbl" for="tooltips-custom-{{chartId}}">Custom format:</label>&nbsp; <input id="" type="text" size="5" style="margin-right:.5em; padding:0 .25em;" ng-model="menuOption.customTooltipFormat" /> &nbsp;<a class="glyphicon glyphicon-info-sign" href="https://github.com/d3/d3-format/blob/master/README.md#format" style="font-size:14px;" target="_blank"></a>
 
 		<br /><label class="chkBoxLbl" for="tooltips-decimalNum-{{chartId}}">'n' number of decimal places: </label>&nbsp; <input id="" type="text" size="5" style="margin-right:.5em; padding:0 .25em;" ng-model="menuOption.decimalNumTooltip" />
 
-		<br /><input class="chkBox pointer" id="tooltip-sort-{{chartId}}" name="tooltip-sort" type="checkbox" ng-model="menuOption.isTooltipSortOn" ng-click="updateStorage()" />&nbsp;<label class="chkBoxLbl" for="tooltip-sort-{{chartId}}" title="Sort tooltip items by value">Tooltip sorting</label>
-
 		<h4 class="sectionTitle btmBdr">Color palletes <a class="glyphicon glyphicon-info-sign" href="https://github.com/d3/d3-scale/blob/master/README.md#schemeCategory10" style="font-size:14px;" target="_blank"></a></h4>
 
 		<select ng-model="menuOption.colorPallete" name="color-pallete">
-			<option value="10" ng-selected="">d3 scheme category 10</option>
-			<option value="20" ng-selected="true">d3 scheme category 20</option>
-			<option value="20b" ng-selected="">d3 scheme category 20b</option>
-			<option value="20c" ng-selected="">d3 scheme category 20c</option>
+			<option value="d3.schemeCategory10" ng-selected="">d3 scheme category 10</option>
+			<option value="d3.schemeCategory20" ng-selected="true">d3 scheme category 20</option>
+			<option value="d3.schemeCategory20b" ng-selected="">d3 scheme category 20b</option>
+			<option value="d3.schemeCategory20c" ng-selected="">d3 scheme category 20c</option>
 		</select>
-
 	</div>
 
 	<div class="clearAll"></div>

--- a/ArgusWeb/app/js/templates/modals/chartOptions.html
+++ b/ArgusWeb/app/js/templates/modals/chartOptions.html
@@ -13,12 +13,12 @@
 				ng-model="menuOption.dateFormat"
 				ng-change="updateDateFormatOutput()"
 				/>
-			<a class="glyphicon glyphicon-info-sign" href="https://github.com/d3/d3-time-format" target="_blank"></a>
+			<a class="glyphicon glyphicon-info-sign" href="https://github.com/d3/d3-time-format" target="_blank" title="Custom d3 date format codes"></a>
 			<div style="margin-left:3em; color:#999;">{{dateFormatOutput}}</div>
 		</div>
 
 		<div style="margin:.5em 0 .5em 1em;">
-			<label><strong>Tick labels:</strong>&nbsp;</label>&nbsp;<a class="glyphicon glyphicon-info-sign" href="https://github.com/d3/d3-format/blob/master/README.md#format" target="_blank"></a>
+			<label><strong>Tick labels:</strong>&nbsp;</label>&nbsp;<a class="glyphicon glyphicon-info-sign" href="https://github.com/d3/d3-format/blob/master/README.md#format" target="_blank" title="Custom d3 format codes"></a>
 
 			<div style="margin:0 0 .5em 1em;" class="hide">
 				<label for="tickFormat-Xaxis-{{chartId}}">X-axis: </label>
@@ -63,7 +63,7 @@
 			<label>output:</label>&nbsp;<span>argus.jvm:mem.nonheap.used</span>
 		</div>
 
-		<h4 class="sectionTitle btmBdr">Downsampling data <a class="glyphicon glyphicon-info-sign" href="https://github.com/d3fc/d3fc-sample" style="font-size:14px;" target="_blank"></a></h4>
+		<h4 class="sectionTitle btmBdr">Downsampling data <a class="glyphicon glyphicon-info-sign" href="https://github.com/d3fc/d3fc-sample" style="font-size:14px;" target="_blank" title="Custom d3 downsample data options"></a></h4>
 
 		<div style="margin:0 0 .5em 1em;">
 			<label>Select a downsample method: </label>&nbsp;
@@ -93,17 +93,21 @@
 
 		<br /><input class="chkBox pointer" id="tooltips-raw-{{chartId}}" type="checkbox" ng-model="menuOption.rawTooltip" title="Display raw data inside tooltips" />&nbsp;<label class="chkBoxLbl" for="tooltips-raw-{{chartId}}">Display raw data point value. <span style="font-weight:normal;">No formatting applied.</span></label>
 
-		<br /><label class="chkBoxLbl" for="tooltips-custom-{{chartId}}">Custom format:</label>&nbsp; <input id="" type="text" size="5" style="margin-right:.5em; padding:0 .25em;" ng-model="menuOption.customTooltipFormat" /> &nbsp;<a class="glyphicon glyphicon-info-sign" href="https://github.com/d3/d3-format/blob/master/README.md#format" style="font-size:14px;" target="_blank"></a>
+		<div style="margin-left:23px;" title="Uncheck raw data point to use">
+			<label class="chkBoxLbl" for="tooltips-custom-{{chartId}}" ng-class="{'disabled': menuOption.rawTooltip}">Custom format:</label>&nbsp; <input type="text" size="5" style="margin-right:.5em; padding:0 .25em;" ng-model="menuOption.customTooltipFormat" ng-disabled="menuOption.rawTooltip" ng-class="{'disabled': menuOption.rawTooltip}" />&nbsp;<a class="glyphicon glyphicon-info-sign" href="https://github.com/d3/d3-format/blob/master/README.md#format" style="font-size:14px;" target="_blank" title="Custom d3 formats"></a>
+		</div>
 
+		<!--
 		<br /><label class="chkBoxLbl" for="tooltips-decimalNum-{{chartId}}">'n' number of decimal places: </label>&nbsp; <input id="" type="text" size="5" style="margin-right:.5em; padding:0 .25em;" ng-model="menuOption.decimalNumTooltip" />
+		-->
 
-		<h4 class="sectionTitle btmBdr">Color palletes <a class="glyphicon glyphicon-info-sign" href="https://github.com/d3/d3-scale/blob/master/README.md#schemeCategory10" style="font-size:14px;" target="_blank"></a></h4>
+		<h4 class="sectionTitle btmBdr">Color palletes <a class="glyphicon glyphicon-info-sign" href="https://github.com/d3/d3-scale/blob/master/README.md#schemeCategory10" style="font-size:14px;" target="_blank" title="Custom d3 color schemes"></a></h4>
 
 		<select ng-model="menuOption.colorPallete" name="color-pallete">
-			<option value="d3.schemeCategory10" ng-selected="">d3 scheme category 10</option>
-			<option value="d3.schemeCategory20" ng-selected="true">d3 scheme category 20</option>
-			<option value="d3.schemeCategory20b" ng-selected="">d3 scheme category 20b</option>
-			<option value="d3.schemeCategory20c" ng-selected="">d3 scheme category 20c</option>
+			<option value="d3.schemeCategory10" ng-selected="menuOption.colorPallete == d3.schemeCategory10">d3 scheme category 10</option>
+			<option value="d3.schemeCategory20" ng-selected="menuOption.colorPallete == d3.schemeCategory20">d3 scheme category 20</option>
+			<option value="d3.schemeCategory20b" ng-selected="menuOption.colorPallete == d3.schemeCategory20b">d3 scheme category 20b</option>
+			<option value="d3.schemeCategory20c" ng-selected="menuOption.colorPallete == d3.schemeCategory20c">d3 scheme category 20c</option>
 		</select>
 	</div>
 
@@ -111,7 +115,9 @@
 
 	<div class="footer">
 		
-		<div class="col-md-6"></div>
+		<div class="col-md-6">
+			<button id="reset" class="btn btn-cancel floatL" style="display:inline-block;" ng-click="resetSettings()">Reset to default settings</button>
+		</div>
 
 		<div class="col-md-6">
 			<input class="chkBox pointer" id="applySettingsAll-{{chartId}}" type="checkbox" ng-model="menuOption.applySettingsAll" title="Apply settings to all graphs" />


### PR DESCRIPTION
Chart updates upon selection inside modal and includes functionality for:

- Date formats
- Y-axis tick format and # (X axis options have been removed)
- Truncation options for metric name displayed in Legend.  Tooltip still needs setup
- Downsampling options
- Brushing & Zooming options
- Tooltip sorting
- Display raw data for datapoint value (tooltip)
- Custom format for datapoint value (tooltip)

Still outstanding:

- Color palette options
- Move Synchronize options to modal
- Apply settings to all graphs
- Reset to default settings
