### PR TITLE
roll back version of chunk manifest webpack plugin

### DIFF
--- a/ArgusWeb/package.json
+++ b/ArgusWeb/package.json
@@ -8,7 +8,7 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "bower": "^1.3.1",
-    "chunk-manifest-webpack-plugin": "^1.0.0",
+    "chunk-manifest-webpack-plugin": "1.0.0",
     "clean-webpack-plugin": "^0.1.15",
     "copy-webpack-plugin": "^4.0.1",
     "css-loader": "^0.26.1",


### PR DESCRIPTION
causes error when running webpack for deployment.