### PR TITLE
remove BETA tab from header

### DIFF
--- a/ArgusWeb/app/js/templates/headerMenu.html
+++ b/ArgusWeb/app/js/templates/headerMenu.html
@@ -17,7 +17,7 @@
                 <li ng-class="{'activeTab': activeTab === 'metrics'}">
                     <a class="glyphicon glyphicon-stats" href="#viewmetrics" title="Metrics"></a>
                 </li>
-                <li ng-class="{'activeTab': activeTab === 'beta'}">
+                <li ng-class="{'activeTab': activeTab === 'beta', 'hide': true}">
                     <a class="betaTab" href="#beta" title="Features currently in Beta testing">Beta</a>
                 </li>
                 <li class="topMenu" ng-class="{'activeTab': activeTab === 'about' || activeTab === 'namespace'}">


### PR DESCRIPTION
Once Metric Discovery service is working again, can add tab back to header.