### PR TITLE
Add local time zone view support and a few bug fixes

### DIFF
--- a/ArgusWeb/app/js/controllers/viewMetrics.js
+++ b/ArgusWeb/app/js/controllers/viewMetrics.js
@@ -11,10 +11,6 @@ angular.module('argus.controllers.viewMetrics', ['ngResource'])
 		$scope.$watch('includeAnnotations', function (newValue) {
 			InputTracker.updateDefaultValue('viewMetricsWithAnnotation', true, newValue);
 		});
-		$scope.timeZoneOption = InputTracker.getDefaultValue('viewMetricsTimeZoneOption', true);
-		$scope.$watch('timeZoneOption', function (newValue) {
-			InputTracker.updateDefaultValue('viewMetricsTimeZoneOption', true, newValue);
-		});
 		// sub-views: (1) single chart, (2) metric discovery
 		$scope.checkMetricExpression = function() {
 			if ($scope.expression) {
@@ -265,7 +261,6 @@ angular.module('argus.controllers.viewMetrics', ['ngResource'])
 					chartScope.dateConfig.startTime = DateHandlerService.getStartTimestamp(series);
 					chartScope.dateConfig.endTime = DateHandlerService.getEndTimestamp(series);
 				}
-				chartScope.dateConfig.gmt = $scope.timeZoneOption;
 
 				// query annotations
 				if (annotationInfo.length > 0) {

--- a/ArgusWeb/app/js/controllers/viewMetrics.js
+++ b/ArgusWeb/app/js/controllers/viewMetrics.js
@@ -35,8 +35,9 @@ angular.module('argus.controllers.viewMetrics', ['ngResource'])
 			var tempSeries = []
 			var annotationInfo = [];
 			if ($scope.expression !== null && $scope.expression.length) {
-				// clear old chart
-				$('#' + 'container').empty();
+				// clear old chart and annotation label tip
+				angular.element('#' + 'container').empty();
+				angular.element('.d3-tip').remove();
 				$scope.checkMetricExpression();
 				// show loading spinner
 				$scope.chartLoaded = false;

--- a/ArgusWeb/app/js/directives/agInfiniteScroll.js
+++ b/ArgusWeb/app/js/directives/agInfiniteScroll.js
@@ -14,11 +14,11 @@ angular.module('argus.directives')
 				scope.infiniteScrollDistance = 5;
 
 				element.on('scroll', function(){
-					var infiniteScoll = attributes.agInfiniteScroll;
+					var infiniteScroll = attributes.agInfiniteScroll;
 					if(this.scrollTop +  scope.infiniteScrollDistance> this.scrollHeight - this.offsetHeight ){
 						$timeout.cancel(timer);
 						timer = $timeout(function(){
-							eval(infiniteScoll);
+							eval(infiniteScroll);
 						}, scrollTimeout);
 					}
 				});

--- a/ArgusWeb/app/js/directives/charts/chart.js
+++ b/ArgusWeb/app/js/directives/charts/chart.js
@@ -7,7 +7,8 @@ angular.module('argus.directives.charts.chart', [])
 		var chartNameIndex = 1;
 		function compileLineChart(scope, newChartId, series, dateConfig, updatedOptionList) {
 			// empty any previous content
-			$('#' + newChartId).empty();
+			angular.element('#' + newChartId).empty();
+			angular.element('.d3-tip').remove();
 
 			// create a new scope to pass to compiled line-chart directive
 			var lineChartScope = scope.$new(false);     // true will set isolate scope, false = inherit

--- a/ArgusWeb/app/js/directives/charts/chart.js
+++ b/ArgusWeb/app/js/directives/charts/chart.js
@@ -187,21 +187,16 @@ angular.module('argus.directives.charts.chart', [])
 
 			// get start and end time for the charts as well as whether GMT/UTC scale is used or not
 			var dateConfig = {};
-			var GMTon = false;
 			for (var i = 0; i < controls.length; i++) {
 				if (controls[i].type === 'agDate') {
 					var timeValue = controls[i].value;
 					if (controls[i].name === 'start') {
 						dateConfig.startTime = DateHandlerService.timeProcessingHelper(timeValue);
-						GMTon = GMTon || DateHandlerService.GMTVerifier(timeValue);
 					} else if (controls[i].name === 'end'){
 						dateConfig.endTime = DateHandlerService.timeProcessingHelper(timeValue);
-						GMTon = GMTon || DateHandlerService.GMTVerifier(timeValue);
 					}
 				}
 			}
-			dateConfig.gmt = GMTon;
-
 			// process data for: metrics, annotations, options
 			var processedData = ChartDataProcessingService.processMetricData(data, controls);
 

--- a/ArgusWeb/app/js/directives/charts/lineChart.js
+++ b/ArgusWeb/app/js/directives/charts/lineChart.js
@@ -1017,12 +1017,10 @@ angular.module('argus.directives.charts.lineChart', [])
 				if (!scope.hideMenu && newValue !== oldValue) {
 					// update x and x2 scale
 					if (newValue) {
-						console.log('using local timezone');
 						GMTon = false;
 						x = d3.scaleTime().domain(x.domain()).range(x.range());
 						x2 = d3.scaleTime().domain(x2.domain()).range(x2.range());
 					} else {
-						console.log('using GMT');
 						GMTon = true;
 						x = d3.scaleUtc().domain(x.domain()).range(x.range());
 						x2 = d3.scaleUtc().domain(x2.domain()).range(x2.range());
@@ -1035,25 +1033,31 @@ angular.module('argus.directives.charts.lineChart', [])
 					xAxis2.scale(x2);
 					xAxisG2.call(xAxis2);
 					// update main chart and brush graphs
-                    if (ChartElementService.customizedChartType.includes(chartType)) {
-                    	ChartElementService.updateCustomizedChartTypeGraphX(mainChart, graph, x, chartType);
-                    	ChartElementService.updateCustomizedChartTypeGraphX(context, graph2, x2, chartType);
-                    } else {
-                        ChartElementService.updateGraphsX(graph, x, timestampSelector);
-                        ChartElementService.updateGraphsX(graph2, x2, timestampSelector);
+					if (ChartElementService.customizedChartType.includes(chartType)) {
+						ChartElementService.updateCustomizedChartTypeGraphX(mainChart, graph, x, chartType);
+						ChartElementService.updateCustomizedChartTypeGraphX(context, graph2, x2, chartType);
+						for (var iSet of extraYAxisSet) {
+							ChartElementService.updateCustomizedChartTypeGraphX(mainChart, extraGraph[iSet], x, chartType);
+							ChartElementService.updateCustomizedChartTypeGraphX(context, extraGraph2[iSet], x2, chartType);
+						}
+					} else {
+						ChartElementService.updateGraphsX(graph, x, timestampSelector);
+						ChartElementService.updateGraphsX(graph2, x2, timestampSelector);
+						for (var iSet of extraYAxisSet) {
+							ChartElementService.updateGraphsX(extraGraph[iSet], x, timestampSelector);
+							ChartElementService.updateGraphsX(extraGraph2[iSet], x2, timestampSelector);
+						}
 
 					}
-                    // TODO: update extraGraph from extraYaxis
 					// update date formatter
 					dateFormatter = ChartToolService.generateDateFormatter(GMTon, scope.menuOption.dateFormat, isSmallChart);
 					scope.dateRange = ChartElementService.updateDateRangeLabel(dateFormatter, GMTon, chartId, x);
-					//
 				}
 			}, true);
 
 			// remove annotation label tip when the user is leaving the page
 			scope.$on("$destroy", function() {
-            	labelTip.destroy();
+				labelTip.destroy();
 			});
 		}
 	};

--- a/ArgusWeb/app/js/directives/charts/lineChart.js
+++ b/ArgusWeb/app/js/directives/charts/lineChart.js
@@ -530,7 +530,7 @@ angular.module('argus.directives.charts.lineChart', [])
 					if (!metric.flagSeries) return;
 					var flagSeries = metric.flagSeries.data;
 					flagSeries.forEach(function (d) {
-						ChartElementService.renderAnnotationsLabels(flagsG, labelTip, tempColor, metric.graphClassName, d, dateFormatter);
+						ChartElementService.renderAnnotationsLabels(flagsG, labelTip, tempColor, metric.graphClassName, d);
 					});
 				});
 				maxScaleExtent = ChartToolService.setZoomExtent(series, zoom);
@@ -1027,13 +1027,23 @@ angular.module('argus.directives.charts.lineChart', [])
 						x = d3.scaleUtc().domain(x.domain()).range(x.range());
 						x2 = d3.scaleUtc().domain(x2.domain()).range(x2.range());
 					}
+					// update axis and grid
 					xAxis.scale(x);
 					xAxisG.call(xAxis);
 					xGrid.scale(x);
 					xGridG.call(xGrid);
 					xAxis2.scale(x2);
 					xAxisG2.call(xAxis2);
-					// TODO: update graph and graph2
+					// update main chart and brush graphs
+                    if (ChartElementService.customizedChartType.includes(chartType)) {
+                    	ChartElementService.updateCustomizedChartTypeGraphX(mainChart, graph, x, chartType);
+                    	ChartElementService.updateCustomizedChartTypeGraphX(context, graph2, x2, chartType);
+                    } else {
+                        ChartElementService.updateGraphsX(graph, x, timestampSelector);
+                        ChartElementService.updateGraphsX(graph2, x2, timestampSelector);
+
+					}
+                    // TODO: update extraGraph from extraYaxis
 					// update date formatter
 					dateFormatter = ChartToolService.generateDateFormatter(GMTon, scope.menuOption.dateFormat, isSmallChart);
 					scope.dateRange = ChartElementService.updateDateRangeLabel(dateFormatter, GMTon, chartId, x);
@@ -1041,6 +1051,10 @@ angular.module('argus.directives.charts.lineChart', [])
 				}
 			}, true);
 
+			// remove annotation label tip when the user is leaving the page
+			scope.$on("$destroy", function() {
+            	labelTip.destroy();
+			});
 		}
 	};
 }]);

--- a/ArgusWeb/app/js/directives/controls/dashboard.js
+++ b/ArgusWeb/app/js/directives/controls/dashboard.js
@@ -18,7 +18,7 @@ angular.module('argus.directives.controls.dashboard', [])
 
 				if (!localSubmit) {
 					for (var prop in $routeParams) {
-						if (prop == $scope.controlName) {
+						if (prop === $scope.controlName) {
 							controlValue = $routeParams[prop];
 						}
 					}
@@ -66,7 +66,7 @@ angular.module('argus.directives.controls.dashboard', [])
 			};
 		},
 		link:function(scope, element, attributes){
-			if (!attributes.onload || attributes.onload == true) {
+			if (!attributes.onload || attributes.onload === true) {
 				scope.$broadcast('submitButtonEvent', scope.controls);
 			}
 		}

--- a/ArgusWeb/app/js/directives/controls/date.js
+++ b/ArgusWeb/app/js/directives/controls/date.js
@@ -34,7 +34,7 @@ angular.module('argus.directives.controls.date', [])
 			};
 		},
 		require: '^agDashboard',
-		template: // TODO: move to external template
+		template:
 			'<strong>{{labelName}} </strong>' +
 			'<div class="dropdown" style="display: inline;">' +
 				'<a class="dropdown-toggle my-toggle-select" id="dLabel" role="button" data-toggle="dropdown" data-target="#" href="">' +

--- a/ArgusWeb/app/js/services/charts/chartElements.js
+++ b/ArgusWeb/app/js/services/charts/chartElements.js
@@ -222,12 +222,12 @@ angular.module('argus.services.charts.elements', [])
 			case 'stackbar':
 				graphElement = this.createStackbar(x, y);
 				break;
-            case 'area':
-                graphElement = this.createArea(x, y);
-                break;
-            case 'stackarea':
-                graphElement = this.createStackArea(x, y);
-                break;
+			case 'area':
+				graphElement = this.createArea(x, y);
+				break;
+			case 'stackarea':
+				graphElement = this.createStackArea(x, y);
+				break;
 			// case 'line':
 			default:
 				graphElement = this.createLine(x, y);
@@ -674,7 +674,7 @@ angular.module('argus.services.charts.elements', [])
 			.on('mouseover', function () {
 				// add timestamp to the annotation label
 				var dateObj = new Date(dataPoint.x);
-				var tempTimestamp = dateObj.toUTCString() + ' (local time: ' + dateObj.toLocaleString() + ')';
+				var tempTimestamp = dateObj.toUTCString() + ' (in this timezone: ' + dateObj.toLocaleString() + ')';
 				tempTimestamp =  '<strong>' + tempTimestamp + '</strong><br/>' + dataPoint.text;
 				labelTip.style('border-color', color).html(tempTimestamp);
 				labelTip.show();
@@ -1509,13 +1509,13 @@ angular.module('argus.services.charts.elements', [])
 		graph.x(function (d) {
 			return UtilService.validNumberChecker(x(timestampSelector(d)));
 		});
-    };
+	};
 
 	this.updateCustomizedChartTypeGraphX = function (chart, graph, x, chartType) {
 		graph.x = x;
-        if (chartType === 'scatter') {
-            chart.selectAll('circle.dot').attr('cx', function (d) { return UtilService.validNumberChecker(x(d[0])); });
-        }
-        // bar charts element do not need to update x attr since they use x0 which is a discrete domain of epoch values
-    };
+		if (chartType === 'scatter') {
+			chart.selectAll('circle.dot').attr('cx', function (d) { return UtilService.validNumberChecker(x(d[0])); });
+		}
+		// bar charts element do not need to update x attr since they use x0 which is a discrete domain of epoch values
+	};
 }]);

--- a/ArgusWeb/app/js/services/charts/chartElements.js
+++ b/ArgusWeb/app/js/services/charts/chartElements.js
@@ -20,6 +20,7 @@ angular.module('argus.services.charts.elements', [])
 	var crossLineTipHeight = 15;
 	var crossLineTipPadding = 3;
 	var extraYAxisPadding = ChartToolService.getExtraYAxisPadding();
+	this.customizedChartType = ['scatter', 'bar', 'stackbar'];
 
 	var setGraphColorStyle = function (graph, color, chartType, opacity) {
 		graph.style('stroke', color);
@@ -215,18 +216,18 @@ angular.module('argus.services.charts.elements', [])
 			case 'scatter':
 				graphElement = this.createScatter(x, y);
 				break;
-			case 'area':
-				graphElement = this.createArea(x, y);
-				break;
-			case 'stackarea':
-				graphElement = this.createStackArea(x, y);
-				break;
 			case 'bar':
 				graphElement = this.createBar(x, y);
 				break;
 			case 'stackbar':
 				graphElement = this.createStackbar(x, y);
 				break;
+            case 'area':
+                graphElement = this.createArea(x, y);
+                break;
+            case 'stackarea':
+                graphElement = this.createStackArea(x, y);
+                break;
 			// case 'line':
 			default:
 				graphElement = this.createLine(x, y);
@@ -639,7 +640,7 @@ angular.module('argus.services.charts.elements', [])
 			.attr('class', className);
 	};
 
-	this.renderAnnotationsLabels = function (flags, labelTip, color, className, dataPoint, dateFormatter) {
+	this.renderAnnotationsLabels = function (flags, labelTip, color, className, dataPoint) {
 		var label = flags.append('g')
 			.attr('class', 'flagItem ' + className)
 			.attr('id', className + dataPoint.flagID)
@@ -672,7 +673,8 @@ angular.module('argus.services.charts.elements', [])
 			})
 			.on('mouseover', function () {
 				// add timestamp to the annotation label
-				var tempTimestamp = dateFormatter(dataPoint.x);
+				var dateObj = new Date(dataPoint.x);
+				var tempTimestamp = dateObj.toUTCString() + ' (local time: ' + dateObj.toLocaleString() + ')';
 				tempTimestamp =  '<strong>' + tempTimestamp + '</strong><br/>' + dataPoint.text;
 				labelTip.style('border-color', color).html(tempTimestamp);
 				labelTip.show();
@@ -1502,4 +1504,18 @@ angular.module('argus.services.charts.elements', [])
 			return null;
 		}
 	};
+
+	this.updateGraphsX = function (graph, x, timestampSelector) {
+		graph.x(function (d) {
+			return UtilService.validNumberChecker(x(timestampSelector(d)));
+		});
+    };
+
+	this.updateCustomizedChartTypeGraphX = function (chart, graph, x, chartType) {
+		graph.x = x;
+        if (chartType === 'scatter') {
+            chart.selectAll('circle.dot').attr('cx', function (d) { return UtilService.validNumberChecker(x(d[0])); });
+        }
+        // bar charts element do not need to update x attr since they use x0 which is a discrete domain of epoch values
+    };
 }]);

--- a/ArgusWeb/app/js/services/charts/chartTools.js
+++ b/ArgusWeb/app/js/services/charts/chartTools.js
@@ -120,7 +120,8 @@ angular.module('argus.services.charts.tools', [])
 			formatYaxis: defaultYaxis,
 			numTicksYaxis: defaultTicksYaxis
 		},
-		isSnapCrosslineOn: true
+		isSnapCrosslineOn: true,
+        localTimezone: false
 	};
 
 	// color

--- a/ArgusWeb/app/js/services/charts/chartTools.js
+++ b/ArgusWeb/app/js/services/charts/chartTools.js
@@ -414,7 +414,7 @@ angular.module('argus.services.charts.tools', [])
 		if (len < 1) return false;
 		var startPoint = timestampSelector(metric.data[0]);
 		var endPoint = timestampSelector(metric.data[len - 1]);
-		return startPoint > xDomain[1] || endPoint < xDomain[xDomain.length - 1];
+		return startPoint > xDomain[xDomain.length - 1] || endPoint < xDomain[0];
 	};
 	var isMetricNotInTheDomain = this.isMetricNotInTheDomain;
 

--- a/ArgusWeb/app/js/services/charts/chartTools.js
+++ b/ArgusWeb/app/js/services/charts/chartTools.js
@@ -121,7 +121,7 @@ angular.module('argus.services.charts.tools', [])
 			numTicksYaxis: defaultTicksYaxis
 		},
 		isSnapCrosslineOn: true,
-        localTimezone: false
+		localTimezone: false
 	};
 
 	// color
@@ -538,9 +538,13 @@ angular.module('argus.services.charts.tools', [])
 
 		finalYMin = (agYMin === undefined) ? UtilService.validNumberChecker(yScalePlain.invert(yMin - buffer)): agYMin;
 		finalYMax = (agYMax === undefined) ? UtilService.validNumberChecker(yScalePlain.invert(yMax + 1.2 * buffer)): agYMax;
-
+		// TODO: need to test with negative values for area and bar charts
 		if (isDataStacked && finalYMin < 0 && yMin !== yMax) finalYMin = 0;
-		if (isChartDiscrete && finalYMin < 0 && yMin < yMax) finalYMin = 0;
+		// if (isChartDiscrete && finalYMin < 0 && yMin < yMax) finalYMin = 0;
+		if (isChartDiscrete && !isDataStacked && finalYMin > 0 && yMin < yMax) {
+			finalYMin = 0;
+			finalYMax *= 1.2;
+		}
 		// TODO: still need to handle log(0) better
 		if (yScaleType === 'log') {
 			if (finalYMin === 0) finalYMin = 1;

--- a/ArgusWeb/app/js/templates/charts/topToolbar.html
+++ b/ArgusWeb/app/js/templates/charts/topToolbar.html
@@ -19,8 +19,10 @@
 
 				<ul style="padding-left:0;">
 				<li ng-repeat="source in sources track by $index">
-					<span class="glyphicon glyphicon-minus {{source.graphClassName}}_legend" ng-style="{color: labelTextColor(source)}"></span>
-					<a ng-click="toggleSource(source)" title="Hide">{{source.name | truncateMetricName:menuOption}}</a> &nbsp;
+					<a ng-click="toggleSource(source)" title="Hide">
+						<span class="glyphicon glyphicon-minus {{source.graphClassName}}_legend" ng-style="{color: labelTextColor(source)}"></span>
+						{{source.name | truncateMetricName:menuOption}}
+					</a>
 					<a class="eyeIcon" title="Hide all other(s)"
 						ng-show="source.displaying && sources.length > 1"
 						ng-click="hideOtherSources(source)"
@@ -119,7 +121,7 @@
 						ng-model="menuOption.downSampleMethod"
 						ng-click="updateDownSample()" />
 						<label for="every-nth-point-{{chartConfig.chartId}}" title="N is calculated based on the container width and # of datapoints)">Every n'th point</label>
-				    </li>
+				</li>
 				</ul>
 			</div>
 

--- a/ArgusWeb/app/js/templates/modals/chartOptions.html
+++ b/ArgusWeb/app/js/templates/modals/chartOptions.html
@@ -14,7 +14,11 @@
 				ng-change="updateDateFormatOutput()"
 				/>
 			<a class="glyphicon glyphicon-info-sign" href="https://github.com/d3/d3-time-format" target="_blank" title="Custom d3 date format codes"></a>
-			<div style="margin-left:3em; color:#999;">{{dateFormatOutput}}</div>
+			<div style="margin-left:3em;">
+				<span style="color:#999; margin-right:3em;">{{dateFormatOutput}}</span>
+				<input class="chkBox pointer" id="toggle-localtimezone-{{chartConfig.chartId}}" type="checkbox" ng-model="menuOption.localTimezone">
+				<label class="chkBoxLbl" for="toggle-localtimezone-{{chartConfig.chartId}}">Use local timezone</label>
+			</div>
 		</div>
 
 		<div style="margin:.5em 0 .5em 1em;">
@@ -63,7 +67,7 @@
 
 		<div style="margin:0 0 .5em 1em;">
 			<input class="chkBox pointer" id="toggle-syncchart-{{chartConfig.chartId}}" type="checkbox" name="toggle-syncchart" ng-model="menuOption.isSyncChart" ng-click="toggleSyncChart()"/>&nbsp;
-			<label for="toggle-syncchart-{{chartConfig.chartId}}" title="Synchronize this chart with other selected charts">Synchronize chart to show X-axis value for each chart</label>
+			<label class="chkBoxLbl" for="toggle-syncchart-{{chartConfig.chartId}}" title="Synchronize this chart with other selected charts">Synchronize chart to show X-axis value for each chart</label>
 		</div>
 	</div>
 

--- a/ArgusWeb/app/js/templates/viewmetrics.html
+++ b/ArgusWeb/app/js/templates/viewmetrics.html
@@ -20,10 +20,6 @@
             <input type="checkbox" ng-model="includeAnnotations">
             Include annotations related to the metric
         </label>
-        <label class="checkbox-inline">
-            <input type="checkbox" ng-model="timeZoneOption">
-            Use GMT
-        </label>
     </div>
 
     <div id="discoveryLookup" ng-show="showMetricDiscovery">


### PR DESCRIPTION
- Add an option to view charts in local time instead of GMT (independent from agDate option)
- Fix the bug of checking if a metric is in the domain incorrectly
- Fix the bug of annotation label stuck on the page after click-to-stay
- Display both local time and GMT in annotation label