### PR TITLE
Use ElasticSearch RestClient instead of vanilla httpclient (Merge into 2.9.0)

### DIFF
--- a/ArgusClient/src/main/java/com/salesforce/dva/argus/client/MetricCommitter.java
+++ b/ArgusClient/src/main/java/com/salesforce/dva/argus/client/MetricCommitter.java
@@ -81,7 +81,7 @@ public class MetricCommitter extends AbstractCommitter {
                     monitorService.modifyCounter(Counter.COMMIT_CLIENT_METRIC_WRITES, dequeuedMetrics.size(), new HashMap<String,String>());
                 }
                 if(noOfDatapointsCommitted>0){
-                	LOGGER.info(MessageFormat.format("Committed {0} datapoints.", noOfDatapointsCommitted));
+                	LOGGER.debug(MessageFormat.format("Committed {0} datapoints.", noOfDatapointsCommitted));
                     jobCounter.addAndGet(noOfDatapointsCommitted);
                     monitorService.modifyCounter(Counter.COMMIT_CLIENT_DATAPOINT_WRITES, noOfDatapointsCommitted, new HashMap<String,String>());
                 }

--- a/ArgusCore/pom.xml
+++ b/ArgusCore/pom.xml
@@ -189,12 +189,12 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.3</version>
+            <version>4.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.3</version>
+            <version>4.4</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -214,7 +214,7 @@
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>eclipselink</artifactId>
-            <version>2.6.2</version>
+            <version>2.6.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.derby</groupId>
@@ -372,7 +372,7 @@
         <dependency>
             <groupId>org.hbase</groupId>
             <artifactId>asynchbase</artifactId>
-            <version>1.7.2</version>
+            <version>1.8.0</version>
         </dependency>
         <dependency>
             <groupId>com.github.brandtg</groupId>
@@ -432,6 +432,11 @@
             <artifactId>concurrent-trees</artifactId>
             <version>2.6.0</version>
         </dependency>
+		<dependency>
+		    <groupId>org.elasticsearch.client</groupId>
+		    <artifactId>rest</artifactId>
+		    <version>5.5.1</version>
+		</dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/entity/KeywordQuery.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/entity/KeywordQuery.java
@@ -2,15 +2,75 @@ package com.salesforce.dva.argus.entity;
 
 import java.text.MessageFormat;
 
+import com.salesforce.dva.argus.service.SchemaService.RecordType;
+
 public class KeywordQuery extends SchemaQuery {
 
+	private String namespace;
+    private String scope;
+    private String metric;
+    private String tagKey;
+    private String tagValue; 
 	private String query;
-    private boolean isNative;
+	private RecordType type;
     
-    public KeywordQuery(String query, boolean isNative, int limit, int page) {
-		super(limit, page);
-		setQuery(query);
-		setNative(isNative);
+    public KeywordQuery(String scope, String metric, String tagKey, String tagValue, String namespace, RecordType type, String query, int limit, int page) {
+    	super(limit, page);
+    	setScope(scope);
+    	setMetric(metric);
+    	setTagKey(tagKey);
+    	setTagValue(tagValue);
+    	setNamespace(namespace);
+    	setType(type);
+    	setQuery(query);
+    }
+    
+	public String getNamespace() {
+		return namespace;
+	}
+
+	public void setNamespace(String namespace) {
+		this.namespace = namespace;
+	}
+
+	public String getScope() {
+		return scope;
+	}
+
+	public void setScope(String scope) {
+		this.scope = scope;
+	}
+
+	public String getMetric() {
+		return metric;
+	}
+
+	public void setMetric(String metric) {
+		this.metric = metric;
+	}
+
+	public String getTagKey() {
+		return tagKey;
+	}
+
+	public void setTagKey(String tagKey) {
+		this.tagKey = tagKey;
+	}
+
+	public String getTagValue() {
+		return tagValue;
+	}
+
+	public void setTagValue(String tagValue) {
+		this.tagValue = tagValue;
+	}
+
+	public RecordType getType() {
+		return type;
+	}
+
+	public void setType(RecordType type) {
+		this.type = type;
 	}
 
 	public String getQuery() {
@@ -20,26 +80,26 @@ public class KeywordQuery extends SchemaQuery {
 	public void setQuery(String query) {
 		this.query = query;
 	}
-
-	public boolean isNative() {
-		return isNative;
-	}
-
-	public void setNative(boolean isNative) {
-		this.isNative = isNative;
-	}
 	
 	@Override
     public String toString() {
-        return MessageFormat.format("KeywordQuery = (Query = {0}, IsNative = {1}, Limit = {2}, Page = {3})", query, isNative, limit, page);
+		return MessageFormat.format("KeywordQuery = (Scope = {0}, Metric = {1}, Tagk = {2}, Tagv = {3}, Namespace = {4}, "
+				+ "Query = {5}, Limit = {6}, Page = {7})", scope, metric, tagKey, tagValue, namespace, query, limit, page);
     }
-    
+	
+	
+
 	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
-		result = prime * result + (isNative ? 1231 : 1237);
+		result = prime * result + ((metric == null) ? 0 : metric.hashCode());
+		result = prime * result + ((namespace == null) ? 0 : namespace.hashCode());
 		result = prime * result + ((query == null) ? 0 : query.hashCode());
+		result = prime * result + ((scope == null) ? 0 : scope.hashCode());
+		result = prime * result + ((tagKey == null) ? 0 : tagKey.hashCode());
+		result = prime * result + ((tagValue == null) ? 0 : tagValue.hashCode());
+		result = prime * result + ((type == null) ? 0 : type.hashCode());
 		return result;
 	}
 
@@ -52,12 +112,37 @@ public class KeywordQuery extends SchemaQuery {
 		if (getClass() != obj.getClass())
 			return false;
 		KeywordQuery other = (KeywordQuery) obj;
-		if (isNative != other.isNative)
+		if (metric == null) {
+			if (other.metric != null)
+				return false;
+		} else if (!metric.equals(other.metric))
+			return false;
+		if (namespace == null) {
+			if (other.namespace != null)
+				return false;
+		} else if (!namespace.equals(other.namespace))
 			return false;
 		if (query == null) {
 			if (other.query != null)
 				return false;
 		} else if (!query.equals(other.query))
+			return false;
+		if (scope == null) {
+			if (other.scope != null)
+				return false;
+		} else if (!scope.equals(other.scope))
+			return false;
+		if (tagKey == null) {
+			if (other.tagKey != null)
+				return false;
+		} else if (!tagKey.equals(other.tagKey))
+			return false;
+		if (tagValue == null) {
+			if (other.tagValue != null)
+				return false;
+		} else if (!tagValue.equals(other.tagValue))
+			return false;
+		if (type != other.type)
 			return false;
 		return true;
 	}
@@ -66,12 +151,48 @@ public class KeywordQuery extends SchemaQuery {
 
 	public static class KeywordQueryBuilder {
 		
+		private String namespace;
+	    private String scope;
+	    private String metric;
+	    private String tagKey;
+	    private String tagValue;
+	    private RecordType type;
 		private String query;
 		private boolean isNative;
 		private int limit = 10;
 		private int page = 1;
 		
 		public KeywordQueryBuilder() {}
+		
+		public KeywordQueryBuilder scope(String scope) {
+	    	this.scope = scope;
+	    	return this;
+	    }
+		
+		public KeywordQueryBuilder metric(String metric) {
+	    	this.metric = metric;
+	    	return this;
+	    }
+		
+		public KeywordQueryBuilder tagKey(String tagKey) {
+	    	this.tagKey = tagKey;
+	    	return this;
+	    }
+		
+		public KeywordQueryBuilder tagValue(String tagValue) {
+	    	this.tagValue = tagValue;
+	    	return this;
+	    }
+		
+		public KeywordQueryBuilder namespace(String namespace) {
+	    	this.namespace = namespace;
+	    	return this;
+	    }
+		
+		public KeywordQueryBuilder type(RecordType type) {
+	    	this.type = type;
+	    	return this;
+	    }
 		
 		public KeywordQueryBuilder query(String query) {
 			this.query = query;
@@ -92,9 +213,9 @@ public class KeywordQuery extends SchemaQuery {
 	    	this.page = page;
 	    	return this;
 	    }
-		
+	    
 		public KeywordQuery build() {
-			return new KeywordQuery(query, isNative, limit, page);
+			return new KeywordQuery(scope, metric, tagKey, tagValue, namespace, type, query, limit, page);
 		}
 	}
 	

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/entity/Metric.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/entity/Metric.java
@@ -222,21 +222,6 @@ public class Metric extends TSDBEntity implements Serializable {
         return _query;
     }
 
-    /**
-     * Constructs a native TSDB metric name for this metric.
-     * @todo This is implementation specific and should be moved to a service interface method.
-     *
-     * @return  The native TSDB metric name for this metric.  This method should never return null.
-     */
-    public String constructTSDBMetricName() {
-        StringBuilder sb = new StringBuilder(getScope());
-
-        if (_namespace != null && !_namespace.isEmpty()) {
-            sb.append(getNamespace());
-        }
-        return sb.toString();
-    }
-
     @Override
     public String toString() {
         Object[] params = {getNamespace(), getScope(), getMetric(), getTags(), getDatapoints() };

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/entity/MetricSchemaRecord.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/entity/MetricSchemaRecord.java
@@ -31,6 +31,7 @@
 	 
 package com.salesforce.dva.argus.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.salesforce.dva.argus.system.SystemAssert;
 import java.text.MessageFormat;
 
@@ -48,7 +49,9 @@ public class MetricSchemaRecord {
     private String namespace;
     private String scope;
     private String metric;
+    @JsonProperty("tagk")
     private String tagKey;
+    @JsonProperty("tagv")
     private String tagValue;
 
     //~ Constructors *********************************************************************************************************************************

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/SchemaService.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/SchemaService.java
@@ -31,6 +31,7 @@
 	 
 package com.salesforce.dva.argus.service;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.salesforce.dva.argus.entity.KeywordQuery;
 import com.salesforce.dva.argus.entity.Metric;
 import com.salesforce.dva.argus.entity.MetricSchemaRecord;
@@ -221,7 +222,7 @@ public interface SchemaService extends Service {
     /**
      * Indicates the schema record field to be used for matching.
      *
-     * @author  Tom Valine (tvaline@salesforce.com)
+     * @author  Bhinav Sura (bhinav.sura@salesforce.com)
      */
     public static enum RecordType {
 
@@ -249,13 +250,15 @@ public interface SchemaService extends Service {
          *
          * @return  The corresponding record type or null if no matching record type exists.
          */
+        @JsonCreator
         public static RecordType fromName(String name) {
             for (RecordType type : RecordType.values()) {
-                if (type.getName().equals(name)) {
+                if (type.getName().equalsIgnoreCase(name)) {
                     return type;
                 }
             }
-            return null;
+            
+            throw new IllegalArgumentException("Illegal record type: " + name);
         }
 
         /**

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/metric/transform/HoltWintersDeviation.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/metric/transform/HoltWintersDeviation.java
@@ -67,8 +67,7 @@ public class HoltWintersDeviation extends HoltWintersAnalysis implements Transfo
 
     @Override
     public List<Metric> transform(List<Metric> metrics) {
-        // TODO Auto-generated method stub
-        return null;
+    	throw new UnsupportedOperationException("HoltWintersDeviation is not supposed to be used without a constant");
     }
 
     @Override
@@ -116,8 +115,7 @@ public class HoltWintersDeviation extends HoltWintersAnalysis implements Transfo
     @SuppressWarnings("unchecked")
     @Override
     public List<Metric> transform(List<Metric>... listOfList) {
-        // TODO Auto-generated method stub
-        return null;
+    	throw new UnsupportedOperationException("HoltWintersDeviation doesn't need list of list!");
     }
 
     @Override

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/metric/transform/HoltWintersForecast.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/metric/transform/HoltWintersForecast.java
@@ -115,8 +115,7 @@ public class HoltWintersForecast extends HoltWintersAnalysis implements Transfor
     @SuppressWarnings("unchecked")
     @Override
     public List<Metric> transform(List<Metric>... listOfList) {
-        // TODO Auto-generated method stub
-        return null;
+    	throw new UnsupportedOperationException("HoltWintersForecast doesn't need list of list!");
     }
 
     @Override

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/schema/AbstractSchemaService.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/schema/AbstractSchemaService.java
@@ -104,7 +104,6 @@ public abstract class AbstractSchemaService extends DefaultService implements Sc
 
 	@Override
 	public void dispose() {
-		throw new UnsupportedOperationException("This method should be overriden by a specific implementation.");
 	}
 
 	@Override

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/schema/DefaultDiscoveryService.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/schema/DefaultDiscoveryService.java
@@ -125,8 +125,6 @@ public class DefaultDiscoveryService extends DefaultService implements Discovery
         List<MetricQuery> expandedQueryList = null;
         
         long start = System.nanoTime();
-        //MetricSchemaRecord scanStartRow = null;
-        
 
         if (DiscoveryService.isWildcardQuery(query)) {
             _logger.info(MessageFormat.format("MetricQuery'{'{0}'}' contains wildcards. Will match against schema records.", query));

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/schema/MetricSchemaRecordList.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/schema/MetricSchemaRecordList.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.salesforce.dva.argus.entity.MetricSchemaRecord;
+import com.salesforce.dva.argus.service.SchemaService.RecordType;
 
 public class MetricSchemaRecordList {
 	
@@ -92,11 +93,18 @@ public class MetricSchemaRecordList {
 				while(iter.hasNext()) {
 					JsonNode hit = iter.next();
 					JsonNode source = hit.get("_source");
-					records.add(new MetricSchemaRecord(source.get("namespace") == null ? null : source.get("namespace").asText(), 
-													   source.get("scope").asText(), 
-													   source.get("metric").asText(), 
-													   source.get("tagKey") == null ? null : source.get("tagKey").asText(), 
-													   source.get("tagValue") == null ? null : source.get("tagValue").asText()));
+					
+					JsonNode namespaceNode = source.get(RecordType.NAMESPACE.getName());
+					JsonNode scopeNode = source.get(RecordType.SCOPE.getName());
+					JsonNode metricNode = source.get(RecordType.METRIC.getName());
+					JsonNode tagkNode = source.get(RecordType.TAGK.getName());
+					JsonNode tagvNode = source.get(RecordType.TAGV.getName());
+					
+					records.add(new MetricSchemaRecord(namespaceNode == null ? null : namespaceNode.asText(), 
+													   scopeNode.asText(), 
+													   metricNode.asText(), 
+													   tagkNode == null ? null : tagkNode.asText(), 
+													   tagvNode == null ? null : tagvNode.asText()));
 				}
 			}
 			

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/tsdb/DefaultTSDBService.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/tsdb/DefaultTSDBService.java
@@ -90,8 +90,8 @@ public class DefaultTSDBService extends DefaultService implements TSDBService {
     private final String _readEndpoint;
     private final CloseableHttpClient _readHttpClient;
     
-    private final Set<String> _writeEndpoints;
-    private final Map<String, CloseableHttpClient> _writeHttpClients = new HashMap<>();
+    private final String[] _writeEndpoints;
+    private final CloseableHttpClient _writeHttpClient;
     
     /** Round robin iterator for write endpoitns. 
      * We will cycle through this iterator to select an endpoint from the set of available endpoints  */
@@ -126,7 +126,7 @@ public class DefaultTSDBService extends DefaultService implements TSDBService {
                 Property.TSD_ENDPOINT_SOCKET_TIMEOUT.getDefaultValue()));
 
         _readEndpoint = config.getValue(Property.TSD_ENDPOINT_READ.getName(), Property.TSD_ENDPOINT_READ.getDefaultValue());
-        _writeEndpoints = new HashSet<>(Arrays.asList(config.getValue(Property.TSD_ENDPOINT_WRITE.getName(), Property.TSD_ENDPOINT_WRITE.getDefaultValue()).split(",")));
+        _writeEndpoints = config.getValue(Property.TSD_ENDPOINT_WRITE.getName(), Property.TSD_ENDPOINT_WRITE.getDefaultValue()).split(",");
         
         requireArgument((_readEndpoint != null) && (!_readEndpoint.isEmpty()), "Illegal read endpoint URL.");
         for(String writeEndpoint : _writeEndpoints) {
@@ -137,12 +137,8 @@ public class DefaultTSDBService extends DefaultService implements TSDBService {
         requireArgument(connTimeout >= 1, "Timeout must be greater than 0.");
         
         try {
-            _readHttpClient = getClient(_readEndpoint, connCount / 2, connTimeout, socketTimeout);
-            
-            for(String writeEndpoint : _writeEndpoints) {
-            	CloseableHttpClient writeHttpClient = getClient(writeEndpoint, connCount / 2, connTimeout, socketTimeout);
-            	_writeHttpClients.put(writeEndpoint, writeHttpClient);
-            }
+            _readHttpClient = getClient(connCount / 2, connTimeout, socketTimeout, _readEndpoint);
+            _writeHttpClient = getClient(connCount / 2, connTimeout, socketTimeout, _writeEndpoints);
             
             _roundRobinIterator = Iterables.cycle(_writeEndpoints).iterator();
             _executorService = Executors.newFixedThreadPool(connCount);
@@ -247,7 +243,7 @@ public class DefaultTSDBService extends DefaultService implements TSDBService {
     public void dispose() {
         super.dispose();
         List<CloseableHttpClient> clients = Arrays.asList(_readHttpClient);
-        clients.addAll(_writeHttpClients.values());
+        clients.add(_writeHttpClient);
         for (CloseableHttpClient client : clients) {
             try {
                 client.close();
@@ -271,7 +267,7 @@ public class DefaultTSDBService extends DefaultService implements TSDBService {
         requireArgument(metrics != null, "Metrics can not be null");
         
         String endpoint = _roundRobinIterator.next();
-        _logger.info("Pushing {} metrics to TSDB using endpoint {}.", metrics.size(), endpoint);
+        _logger.debug("Pushing {} metrics to TSDB using endpoint {}.", metrics.size(), endpoint);
 
         List<Metric> fracturedList = new ArrayList<>();
 
@@ -287,7 +283,7 @@ public class DefaultTSDBService extends DefaultService implements TSDBService {
         	put(fracturedList, endpoint + "/api/put", HttpMethod.POST);
         } catch(IOException ex) {
         	_logger.warn("IOException while trying to push metrics", ex);
-        	List<String> copy = new ArrayList<>(_writeEndpoints);
+        	List<String> copy = Arrays.asList(_writeEndpoints);
         	copy.remove(endpoint);
         	_retry(fracturedList, copy);
         }
@@ -364,7 +360,7 @@ public class DefaultTSDBService extends DefaultService implements TSDBService {
             	put(wrappers, endpoint + "/api/annotation/bulk", HttpMethod.POST);
             } catch(IOException ex) {
             	_logger.warn("IOException while trying to push annotations", ex);
-            	List<String> copy = new ArrayList<>(_writeEndpoints);
+            	List<String> copy = Arrays.asList(_writeEndpoints);
             	copy.remove(endpoint);
             	_retry(wrappers, copy);
             }
@@ -447,23 +443,21 @@ public class DefaultTSDBService extends DefaultService implements TSDBService {
     }
 
     /* Helper to create the read and write clients. */
-    private CloseableHttpClient getClient(String endpoint, int connCount, int connTimeout, int socketTimeout) throws MalformedURLException {
-        URL url = new URL(endpoint);
-        int port = url.getPort();
-
-        requireArgument(port != -1, "Read endpoint must include explicit port.");
-
+    private CloseableHttpClient getClient(int connCount, int connTimeout, int socketTimeout, String...endpoints) throws MalformedURLException {
         PoolingHttpClientConnectionManager connMgr = new PoolingHttpClientConnectionManager();
-
         connMgr.setMaxTotal(connCount);
-        connMgr.setDefaultMaxPerRoute(connCount);
-
-        String route = endpoint.substring(0, endpoint.lastIndexOf(":"));
-        HttpHost host = new HttpHost(route, port);
+        
+        for(String endpoint : endpoints) {
+        	URL url = new URL(endpoint);
+            int port = url.getPort();
+            requireArgument(port != -1, "TSDB endpoint must include explicit port.");
+            HttpHost host = new HttpHost(url.getHost(),	url.getPort());
+            connMgr.setMaxPerRoute(new HttpRoute(host), connCount / endpoints.length);
+        }
+        
         RequestConfig reqConfig = RequestConfig.custom().setConnectionRequestTimeout(connTimeout).setConnectTimeout(connTimeout).setSocketTimeout(
             socketTimeout).build();
 
-        connMgr.setMaxPerRoute(new HttpRoute(host), connCount / 2);
         return HttpClients.custom().setConnectionManager(connMgr).setDefaultRequestConfig(reqConfig).build();
     }
 
@@ -583,24 +577,12 @@ public class DefaultTSDBService extends DefaultService implements TSDBService {
         }
         return null;
     }
-
-    private CloseableHttpClient _chooseWriteEndpoint(String url) {
-    	String defaultWriteEndpoint = "";
-    	for(String writeEndpoint : _writeEndpoints) {
-    		defaultWriteEndpoint = writeEndpoint;
-    		if(url.startsWith(writeEndpoint)) {
-    			return _writeHttpClients.get(writeEndpoint);
-    		}
-    	}
-    	
-    	return _writeHttpClients.get(defaultWriteEndpoint);
-    }
     
     /* Execute a request given by type requestType. */
     @SuppressWarnings("resource")
     private HttpResponse executeHttpRequest(HttpMethod requestType, String url, StringEntity entity) throws IOException {
         HttpResponse httpResponse = null;
-        CloseableHttpClient client = url.startsWith(_readEndpoint) ? _readHttpClient : _chooseWriteEndpoint(url);
+        CloseableHttpClient client = url.startsWith(_readEndpoint) ? _readHttpClient : _writeHttpClient;
 
         if (entity != null) {
             entity.setContentType("application/json");

--- a/ArgusCore/src/test/java/com/salesforce/dva/argus/service/schema/AbstractSchemaServiceTest.java
+++ b/ArgusCore/src/test/java/com/salesforce/dva/argus/service/schema/AbstractSchemaServiceTest.java
@@ -24,7 +24,7 @@ import com.salesforce.dva.argus.service.schema.ElasticSearchSchemaService;
  * ElasticSearchSchemaService object, the implemtationSpecificPut (which is part of ES Schema Service) has been 
  * mocked out. In essence, these tests only test the caching functionality. 
  * 
- * @author bhinav.sura
+ * @author Bhinav Sura (bhinav.sura@salesforce.com)
  *
  */
 public class AbstractSchemaServiceTest extends AbstractTest {

--- a/ArgusSDK/src/main/java/com/salesforce/dva/argus/sdk/entity/MetricDiscoveryQuery.java
+++ b/ArgusSDK/src/main/java/com/salesforce/dva/argus/sdk/entity/MetricDiscoveryQuery.java
@@ -5,75 +5,90 @@ import java.io.Serializable;
 @SuppressWarnings("serial")
 public class MetricDiscoveryQuery implements Serializable{
 	
-	private static int DEFAULT_LIMIT=50;
+	private static int DEFAULT_LIMIT = 50;
 
 	    private String namespace;
 	    private String scope;
 	    private String metric;
-	    private String tagKey;
-	    private String tagValue;
+	    private String tagk;
+	    private String tagv;
 	    private int limit;
 	    private String type;
 	    private MetricSchemaRecord scanStartSchemaRecord;
 	    
 	    public MetricDiscoveryQuery(){};
-	    public MetricDiscoveryQuery(String namespace, String scope, String metric, String tagKey, String tagValue, 
-	    		int limit,String type, MetricSchemaRecord scanStartSchemarecord){
-	    	this.namespace=namespace;
-	    	this.scope=scope;
-	    	this.metric=metric;
-	    	this.tagKey=tagKey;
-	    	this.tagValue=tagValue;
-	    	this.limit=limit;
-	    	this.type=type;
-	    	this.scanStartSchemaRecord=scanStartSchemarecord;
+	    public MetricDiscoveryQuery(String namespace, String scope, String metric, String tagk, String tagv, int limit, 
+	    		String type, MetricSchemaRecord scanStartSchemarecord){
+	    	setNamespace(namespace);
+	    	setScope(scope);
+	    	setMetric(metric);
+	    	setTagk(tagk);
+	    	setTagv(tagv);
+	    	setLimit(limit);
+	    	setType(type);
+	    	setScanStartMetricSchemaRecord(scanStartSchemarecord);
 	    }
 	    
 		public String getNamespace() {
-			return namespace==null || namespace.length()==0?"*":namespace;
+			return namespace == null || namespace.length() == 0 ? "*" : namespace;
 		}
+		
 		public void setNamespace(String namespace) {
 			this.namespace = namespace;
 		}
+		
 		public String getScope() {
 			return scope;
 		}
+		
 		public void setScope(String scope) {
 			this.scope = scope;
 		}
+		
 		public String getMetric() {
 			return metric;
 		}
+		
 		public void setMetric(String metric) {
 			this.metric = metric;
 		}
-		public String getTagKey() {
-			return tagKey==null || tagKey.length()==0?"*":tagKey;
+		
+		public String getTagk() {
+			return tagk == null || tagk.length() == 0 ? "*" : tagk;
 		}
-		public void setTagKey(String tagKey) {
-			this.tagKey = tagKey;
+		
+		public void setTagk(String tagk) {
+			this.tagk = tagk;
 		}
-		public String getTagValue() {
-			return tagValue==null || tagValue.length()==0?"*":tagValue;
+		
+		public String getTagv() {
+			return tagv == null || tagv.length() ==0 ? "*" : tagv;
 		}
-		public void setTagValue(String tagValue) {
-			this.tagValue = tagValue;
+		
+		public void setTagv(String tagv) {
+			this.tagv = tagv;
 		}
+		
 		public int getLimit() {
-			return limit==0?DEFAULT_LIMIT:limit;
+			return limit == 0 ? DEFAULT_LIMIT : limit;
 		}
+		
 		public void setLimit(int limit) {
 			this.limit = limit;
 		}
+		
 		public String getType() {
 			return type;
 		}
+		
 		public void setType(String type) {
 			this.type = type;
 		}
+		
 		public MetricSchemaRecord getScanStartSchemaRecord() {
 			return scanStartSchemaRecord;
 		}
+		
 		public void setScanStartMetricSchemaRecord(MetricSchemaRecord scanStartSchemaRecord) {
 			this.scanStartSchemaRecord = scanStartSchemaRecord;
 		}

--- a/ArgusSDK/src/main/java/com/salesforce/dva/argus/sdk/entity/MetricSchemaRecord.java
+++ b/ArgusSDK/src/main/java/com/salesforce/dva/argus/sdk/entity/MetricSchemaRecord.java
@@ -46,8 +46,8 @@ public final class MetricSchemaRecord {
     private String namespace;
     private String scope;
     private String metric;
-    private String tagKey;
-    private String tagValue;
+    private String tagk;
+    private String tagv;
 
     //~ Constructors *********************************************************************************************************************************
 
@@ -70,15 +70,15 @@ public final class MetricSchemaRecord {
      * @param  namespace  The metric schema namespace.
      * @param  scope      The metric schema scope.
      * @param  metric     The metric schema name.
-     * @param  tagKey     The metric schema tag key.
-     * @param  tagValue   The metric schema tag value.
+     * @param  tagk       The metric schema tag key.
+     * @param  tagv   	  The metric schema tag value.
      */
-    public MetricSchemaRecord(String namespace, String scope, String metric, String tagKey, String tagValue) {
+    public MetricSchemaRecord(String namespace, String scope, String metric, String tagk, String tagv) {
         setNamespace(namespace);
         setScope(scope);
         setMetric(metric);
-        setTagKey(tagKey);
-        setTagValue(tagValue);
+        setTagk(tagk);
+        setTagv(tagv);
     }
 
     //~ Methods **************************************************************************************************************************************
@@ -143,7 +143,7 @@ public final class MetricSchemaRecord {
      * @return  The tag key. Can be null.
      */
     public String getTagKey() {
-        return tagKey;
+        return tagk;
     }
 
     /**
@@ -151,8 +151,8 @@ public final class MetricSchemaRecord {
      *
      * @param  tagKey  The tag key. Can be null.
      */
-    public void setTagKey(String tagKey) {
-        this.tagKey = tagKey;
+    public void setTagk(String tagk) {
+        this.tagk = tagk;
     }
 
     /**
@@ -161,7 +161,7 @@ public final class MetricSchemaRecord {
      * @return  The tag value. Can be null.
      */
     public String getTagValue() {
-        return tagValue;
+        return tagv;
     }
 
     /**
@@ -169,8 +169,8 @@ public final class MetricSchemaRecord {
      *
      * @param  tagValue  The tag value. Can be null.
      */
-    public void setTagValue(String tagValue) {
-        this.tagValue = tagValue;
+    public void setTagv(String tagv) {
+        this.tagv = tagv;
     }
 
     @Override
@@ -180,8 +180,8 @@ public final class MetricSchemaRecord {
         hash = 89 * hash + Objects.hashCode(this.namespace);
         hash = 89 * hash + Objects.hashCode(this.scope);
         hash = 89 * hash + Objects.hashCode(this.metric);
-        hash = 89 * hash + Objects.hashCode(this.tagKey);
-        hash = 89 * hash + Objects.hashCode(this.tagValue);
+        hash = 89 * hash + Objects.hashCode(this.tagk);
+        hash = 89 * hash + Objects.hashCode(this.tagv);
         return hash;
     }
 
@@ -208,10 +208,10 @@ public final class MetricSchemaRecord {
         if (!Objects.equals(this.metric, other.metric)) {
             return false;
         }
-        if (!Objects.equals(this.tagKey, other.tagKey)) {
+        if (!Objects.equals(this.tagk, other.tagk)) {
             return false;
         }
-        return Objects.equals(this.tagValue, other.tagValue);
+        return Objects.equals(this.tagv, other.tagv);
     }
 }
 /* Copyright (c) 2016, Salesforce.com, Inc.  All rights reserved. */

--- a/ArgusSDK/src/test/java/com/salesforce/dva/argus/sdk/DiscoveryServiceTest.java
+++ b/ArgusSDK/src/test/java/com/salesforce/dva/argus/sdk/DiscoveryServiceTest.java
@@ -98,8 +98,8 @@ public class DiscoveryServiceTest extends AbstractTest {
         result.setMetric("metReg");
         result.setNamespace("nsReg");
         result.setScope("scpReg");
-        result.setTagKey("tkReg");
-        result.setTagValue("tvReg");
+        result.setTagk("tkReg");
+        result.setTagv("tvReg");
         return result;
     }
 }

--- a/ArgusSDK/src/test/resources/DiscoveryServiceTest.json
+++ b/ArgusSDK/src/test/resources/DiscoveryServiceTest.json
@@ -4,7 +4,7 @@
     "jsonInput" :null,
     "status": 200,
     "message": "success",
-    "jsonOutput" : "[{\"namespace\":\"nsReg\",\"scope\":\"scpReg\",\"metric\":\"metReg\",\"tagKey\":\"tkReg\",\"tagValue\":\"tvReg\"}]"
+    "jsonOutput" : "[{\"namespace\":\"nsReg\",\"scope\":\"scpReg\",\"metric\":\"metReg\",\"tagk\":\"tkReg\",\"tagv\":\"tvReg\"}]"
 },{
     "type": "GET",
     "endpoint": "/discover/metrics/schemarecords?namespace=nsReg&scope=scpReg&metric=metReg&tagk=tkReg&tagv=tvReg&limit=2&type=namespace",
@@ -15,14 +15,14 @@
 },{
     "type": "POST",
     "endpoint": "/discover/metrics/schemarecords",
-    "jsonInput" : "{\"namespace\":\"*\",\"scope\":\"scpReg\",\"metric\":\"*\",\"tagKey\":\"*\",\"tagValue\":\"*\",\"limit\":10,\"type\":null,\"scanStartSchemaRecord\":null}",
+    "jsonInput" : "{\"namespace\":\"*\",\"scope\":\"scpReg\",\"metric\":\"*\",\"tagk\":\"*\",\"tagv\":\"*\",\"limit\":10,\"type\":null,\"scanStartSchemaRecord\":null}",
     "status": 200,
     "message": "success",
-    "jsonOutput" : "{\"data\":[{\"namespace\":\"nsReg\",\"scope\":\"scpReg\",\"metric\":\"metReg\",\"tagKey\":\"tkReg\",\"tagValue\":\"tvReg\"}],\"lastSchemaRecord\":null}"
+    "jsonOutput" : "{\"data\":[{\"namespace\":\"nsReg\",\"scope\":\"scpReg\",\"metric\":\"metReg\",\"tagk\":\"tkReg\",\"tagv\":\"tvReg\"}],\"lastSchemaRecord\":null}"
 },{
     "type": "POST",
     "endpoint": "/discover/metrics/schemarecords",
-    "jsonInput" : "{\"namespace\":\"*\",\"scope\":\"scpReg\",\"metric\":\"*\",\"tagKey\":\"*\",\"tagValue\":\"*\",\"limit\":10,\"type\":\"namespace\",\"scanStartSchemaRecord\":null}",
+    "jsonInput" : "{\"namespace\":\"*\",\"scope\":\"scpReg\",\"metric\":\"*\",\"tagk\":\"*\",\"tagv\":\"*\",\"limit\":10,\"type\":\"namespace\",\"scanStartSchemaRecord\":null}",
     "status": 200,
     "message": "success",
     "jsonOutput" : "{\"data\":[\"namespace1\",\"namespace2\"],\"lastSchemaRecord\":null}"

--- a/ArgusWebServices/src/main/java/com/salesforce/dva/argus/ws/dto/MetricDiscoveryQueryDto.java
+++ b/ArgusWebServices/src/main/java/com/salesforce/dva/argus/ws/dto/MetricDiscoveryQueryDto.java
@@ -2,20 +2,20 @@ package com.salesforce.dva.argus.ws.dto;
 
 import java.util.Arrays;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.salesforce.dva.argus.entity.MetricSchemaRecord;
+import com.salesforce.dva.argus.service.SchemaService.RecordType;
 
 public class MetricDiscoveryQueryDto extends BaseDto{
 
 	    private String namespace;
 	    private String scope;
 	    private String metric;
-	    private String tagKey;
-	    private String tagValue;
-	    private int limit = 50;
-	    private String type;
+	    private String tagk;
+	    private String tagv;
+	    private RecordType type;
 	    private MetricSchemaRecord scanStartSchemaRecord;
 	    private int page = 1;
+	    private int limit = 50;
 	    
 	    private String keywordQuery;
 	    private boolean isKeywordQueryNative;
@@ -44,22 +44,20 @@ public class MetricDiscoveryQueryDto extends BaseDto{
 			this.metric = metric;
 		}
 		
-		public String getTagKey() {
-			return tagKey == null || tagKey.length() == 0 ? "*" : tagKey;
+		public String getTagk() {
+			return tagk == null || tagk.length() == 0 ? "*" : tagk;
 		}
 		
-		@JsonProperty("tagk")
-		public void setTagKey(String tagKey) {
-			this.tagKey = tagKey;
+		public void setTagk(String tagk) {
+			this.tagk = tagk;
 		}
 		
-		public String getTagValue() {
-			return tagValue == null || tagValue.length() == 0 ? "*" : tagValue;
+		public String getTagv() {
+			return tagv == null || tagv.length() == 0 ? "*" : tagv;
 		}
 		
-		@JsonProperty("tagv")
-		public void setTagValue(String tagValue) {
-			this.tagValue = tagValue;
+		public void setTagv(String tagv) {
+			this.tagv = tagv;
 		}
 		
 		public int getLimit() {
@@ -70,11 +68,11 @@ public class MetricDiscoveryQueryDto extends BaseDto{
 			this.limit = limit;
 		}
 		
-		public String getType() {
+		public RecordType getType() {
 			return type;
 		}
 		
-		public void setType(String type) {
+		public void setType(RecordType type) {
 			this.type = type;
 		}
 		
@@ -112,25 +110,25 @@ public class MetricDiscoveryQueryDto extends BaseDto{
 
 		@Override
 		public Object createExample() {
-			MetricDiscoveryQueryDto result = new MetricDiscoveryQueryDto();
-			result.setNamespace("namespace");
-			result.setScope("scope*");
-			result.setMetric("metric");
-			result.setTagKey("tagKey");
-			result.setTagValue("tagValue");
-			result.setLimit(10);
-			result.setType("scope");
-			result.setScanStartMetricSchemaRecord(new MetricSchemaRecord("scope1", "metric", "tagKey", "tagValue", "namespace")); 
+			MetricDiscoveryQueryDto query = new MetricDiscoveryQueryDto();
+			query.setNamespace("namespace");
+			query.setScope("scope*");
+			query.setMetric("metric");
+			query.setTagk("tagKey");
+			query.setTagv("tagValue");
+			query.setLimit(10);
+			query.setType(RecordType.SCOPE);
+			query.setScanStartMetricSchemaRecord(new MetricSchemaRecord("scope1", "metric", "tagKey", "tagValue", "namespace")); 
 			
-			MetricDiscoveryQueryDto anotherResult = new MetricDiscoveryQueryDto();
-			anotherResult.setNamespace("namespace");
-			anotherResult.setScope("scope");
-			anotherResult.setMetric("metric");
-			anotherResult.setTagKey("tagKey");
-			anotherResult.setTagValue("tagValue");
-			anotherResult.setLimit(10);
-			anotherResult.setType("scope");
-			anotherResult.setPage(1);
+			MetricDiscoveryQueryDto anotherQuery = new MetricDiscoveryQueryDto();
+			anotherQuery.setNamespace("namespace");
+			anotherQuery.setScope("scope");
+			anotherQuery.setMetric("metric");
+			anotherQuery.setTagk("tagKey");
+			anotherQuery.setTagv("tagValue");
+			anotherQuery.setLimit(10);
+			anotherQuery.setType(RecordType.SCOPE);
+			anotherQuery.setPage(1);
 			
 			MetricDiscoveryQueryDto yetAnotherResult = new MetricDiscoveryQueryDto();
 			yetAnotherResult.setKeywordQuery("cpu time");
@@ -138,7 +136,7 @@ public class MetricDiscoveryQueryDto extends BaseDto{
 			yetAnotherResult.setPage(1);
 			yetAnotherResult.setKeywordQueryNative(false);
 			
-			return Arrays.asList(result, anotherResult, yetAnotherResult);
+			return Arrays.asList(query, anotherQuery, yetAnotherResult);
 		}
 	    
 	    

--- a/ArgusWebServices/src/main/java/com/salesforce/dva/argus/ws/dto/NamespaceDto.java
+++ b/ArgusWebServices/src/main/java/com/salesforce/dva/argus/ws/dto/NamespaceDto.java
@@ -35,7 +35,11 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.salesforce.dva.argus.entity.Namespace;
 import com.salesforce.dva.argus.entity.PrincipalUser;
 import com.salesforce.dva.argus.system.SystemAssert;
+
+import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -152,8 +156,17 @@ public class NamespaceDto extends EntityDTO {
 
     @Override
     public Object createExample() {
-        // TODO Auto-generated method stub
-        return null;
+        NamespaceDto result = new NamespaceDto();
+        
+        result.setCreatedById(BigInteger.ONE);
+        result.setCreatedDate(new Date());
+        result.setId(BigInteger.ONE);
+        result.setModifiedById(BigInteger.TEN);
+        result.setModifiedDate(new Date());
+        result.setQualifier("example-namespace");
+        result.setUsernames(new HashSet<>(Arrays.asList("aUser", "bUser", "cUSer")));
+        
+        return result;
     }
 }
 /* Copyright (c) 2016, Salesforce.com, Inc.  All rights reserved. */


### PR DESCRIPTION
Advantages of using ES rest client:
- minimal dependencies
- load balancing across all available nodes
- failover in case of node failures and upon specific response codes
- failed connection penalization (whether a failed node is retried depends on how many consecutive times it failed; the more failed attempts the longer the client will wait before trying that same node again)
- persistent connections
- trace logging of requests and responses
- optional automatic discovery of cluster nodes

@rajsarkapally-sfdc @dilipdevaraj-sfdc 