### PR TITLE
Dependency security updates

### DIFF
--- a/ArgusCore/pom.xml
+++ b/ArgusCore/pom.xml
@@ -197,17 +197,14 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.3.5</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.3.5</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.3.5</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>

--- a/ArgusCore/pom.xml
+++ b/ArgusCore/pom.xml
@@ -173,12 +173,10 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.1.7</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.1.7</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/ArgusCore/pom.xml
+++ b/ArgusCore/pom.xml
@@ -187,7 +187,6 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/ArgusSDK/pom.xml
+++ b/ArgusSDK/pom.xml
@@ -153,12 +153,10 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.1.7</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.1.7</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/ArgusSDK/pom.xml
+++ b/ArgusSDK/pom.xml
@@ -143,12 +143,10 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.6.5</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.6.5</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
@@ -161,7 +159,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.6.5</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/ArgusSDK/pom.xml
+++ b/ArgusSDK/pom.xml
@@ -138,7 +138,6 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.4.1</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/ArgusWebServices/pom.xml
+++ b/ArgusWebServices/pom.xml
@@ -197,17 +197,14 @@
         <dependency>
         	<groupId>com.fasterxml.jackson.core</groupId>
         	<artifactId>jackson-annotations</artifactId>
-        	<version>2.3.2</version>
         </dependency>
         <dependency>
         	<groupId>com.fasterxml.jackson.jaxrs</groupId>
         	<artifactId>jackson-jaxrs-base</artifactId>
-        	<version>2.3.2</version>
         </dependency>
         <dependency>
         	<groupId>com.fasterxml.jackson.jaxrs</groupId>
         	<artifactId>jackson-jaxrs-json-provider</artifactId>
-        	<version>2.3.2</version>
         </dependency>
         <dependency>
         	<groupId>org.glassfish.jersey.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,7 @@
         <dockerImages.base.name>rmelick</dockerImages.base.name>
         <project.version>2.10.0</project.version>
         <logback.version>1.2.3</logback.version>
+        <jackson.version>2.9.2</jackson.version>
     </properties>
     <build>
         <filters>
@@ -397,6 +398,36 @@
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-core</artifactId>
                 <version>${logback.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                <artifactId>jackson-jaxrs-base</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                <artifactId>jackson-jaxrs-json-provider</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-jaxb-annotations</artifactId>
+                <version>${jackson.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,7 @@
         <project.version>2.10.0</project.version>
         <logback.version>1.2.3</logback.version>
         <jackson.version>2.9.2</jackson.version>
+        <httpclient.version>4.5.3</httpclient.version>
     </properties>
     <build>
         <filters>
@@ -428,6 +429,11 @@
                 <groupId>com.fasterxml.jackson.module</groupId>
                 <artifactId>jackson-module-jaxb-annotations</artifactId>
                 <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>${httpclient.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,7 @@
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
         <dockerImages.base.name>rmelick</dockerImages.base.name>
         <project.version>2.10.0</project.version>
+        <logback.version>1.2.3</logback.version>
     </properties>
     <build>
         <filters>
@@ -385,6 +386,20 @@
             </build>
         </profile>
     </profiles>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${logback.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <version>${logback.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <modules>
         <module>ArgusCore</module>
         <module>ArgusWeb</module>


### PR DESCRIPTION
To fix #673: Addressing some security vulnerabilities in dependency versions and moving version declaration to the parent POM's `dependencyManagement` section.

# logback version 1.2.3 (latest) to fix CVE/CWE
* CVE: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5929
* CWE: https://cwe.mitre.org/data/definitions/502.html
* Found at https://snyk.io/vuln/SNYK-JAVA-CHQOSLOGBACK-30208

# Jackson 2.9.2 (latest) to address CVE/CWE
* CVE: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-7525
* CWE: https://cwe.mitre.org/data/definitions/502.html
* Found via https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-31507, https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-31519, https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-31520

# httpcomponents:httpclient:4.5.3 (latest) for CWE
* CWE: https://cwe.mitre.org/data/definitions/23.html
* Found in https://snyk.io/vuln/SNYK-JAVA-ORGAPACHEHTTPCOMPONENTS-31517