### PR TITLE
Refactor ESSchemaService and FILL Transform bug fix

### DIFF
--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/metric/transform/FillCalculateTransform.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/metric/transform/FillCalculateTransform.java
@@ -160,6 +160,8 @@ public class FillCalculateTransform implements Transform {
                 newConstants.add(constants.get(1));
                 newConstants.add(constants.get(2));
                 newConstants.add(String.valueOf(calculateResult));
+                newConstants.add(String.valueOf(System.currentTimeMillis()));
+                newConstants.add("false");
 
                 List<Metric> singleMetric = new ArrayList<>();
 

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/metric/transform/FillTransform.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/metric/transform/FillTransform.java
@@ -203,7 +203,7 @@ public class FillTransform implements Transform {
     	
     	// Last 2 constants for FILL Transform are added by MetricReader. 
     	// The last constant is used to distinguish between FILL(expr, #constants#) and FILL(#constants#).
-    	// The second last transform is the timestamp using which relative start and end timestamps 
+    	// The second last constant is the timestamp using which relative start and end timestamps 
     	// should be calculated for fillLine ( FILL(#constants#) ).
     	
     	boolean constantsOnly = false;

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/metric/transform/FillTransform.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/metric/transform/FillTransform.java
@@ -201,9 +201,6 @@ public class FillTransform implements Transform {
     @Override
     public List<Metric> transform(List<Metric> metrics, List<String> constants) {
     	
-    	// Last constant for FILL Transform is added by MetricReader. It is used to distinguish 
-    	// between FILL(expr, #constants#) and FILL(#constants#).
-    	
     	// Last 2 constants for FILL Transform are added by MetricReader. 
     	// The last constant is used to distinguish between FILL(expr, #constants#) and FILL(#constants#).
     	// The second last transform is the timestamp using which relative start and end timestamps 

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/metric/transform/FillTransform.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/metric/transform/FillTransform.java
@@ -37,6 +37,7 @@ import com.salesforce.dva.argus.system.SystemAssert;
 import com.salesforce.dva.argus.system.SystemException;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -60,6 +61,10 @@ public class FillTransform implements Transform {
     //~ Methods **************************************************************************************************************************************
 
     private static Map<Long, Double> _fillMetricTransform(Metric metric, long windowSizeInSeconds, long offsetInSeconds, double value) {
+    	if(metric == null || metric.getDatapoints() == null || metric.getDatapoints().isEmpty()) {
+    		return Collections.emptyMap();
+    	}
+    	
         Map<Long, Double> filledDatapoints = new TreeMap<>();
         Map<Long, Double> sortedDatapoints = new TreeMap<>(metric.getDatapoints());
         Long[] sortedTimestamps = new Long[sortedDatapoints.size()];
@@ -196,17 +201,31 @@ public class FillTransform implements Transform {
     @Override
     public List<Metric> transform(List<Metric> metrics, List<String> constants) {
     	
-        if (metrics == null || metrics.isEmpty()) {
-        	// Last constant is added by MetricReader. It is the timestamp using which relative start and end timestamps 
-        	// should be calculated
-        	String relativeTo = "";
-        	if(constants != null && !constants.isEmpty()) {
-        		relativeTo = constants.remove(constants.size() - 1);
-        	}
-            return _fillLine(constants, Long.parseLong(relativeTo));
+    	// Last constant for FILL Transform is added by MetricReader. It is used to distinguish 
+    	// between FILL(expr, #constants#) and FILL(#constants#).
+    	
+    	// Last 2 constants for FILL Transform are added by MetricReader. 
+    	// The last constant is used to distinguish between FILL(expr, #constants#) and FILL(#constants#).
+    	// The second last transform is the timestamp using which relative start and end timestamps 
+    	// should be calculated for fillLine ( FILL(#constants#) ).
+    	
+    	boolean constantsOnly = false;
+    	if(constants != null && !constants.isEmpty()) {
+    		constantsOnly = Boolean.parseBoolean(constants.get(constants.size()-1));
+    		constants.remove(constants.size()-1);
+    	}
+    	
+    	long relativeTo = System.currentTimeMillis();
+    	if(constants != null && !constants.isEmpty()) {
+    		relativeTo = Long.parseLong(constants.get(constants.size()-1));
+    		constants.remove(constants.size() - 1);
+    	}
+    	
+        if (constantsOnly) {
+            return _fillLine(constants, relativeTo);
         }
         
-        SystemAssert.requireArgument(metrics != null, "Cannot transform null or empty metrics!");
+        SystemAssert.requireArgument(metrics != null, "Cannot transform null metrics list!");
         SystemAssert.requireArgument(constants != null && constants.size() == 3, 
         		"Fill Transform needs exactly three constants: interval, offset, value");
 

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/schema/AbstractSchemaService.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/schema/AbstractSchemaService.java
@@ -60,7 +60,7 @@ public abstract class AbstractSchemaService extends DefaultService implements Sc
 		
 		for(Metric metric : metrics) {
 			if(metric.getTags().isEmpty()) {
-				String key = _constructTrieKey(metric, null);
+				String key = constructTrieKey(metric, null);
 				boolean found = _trie.getValueForExactKey(key) != null;
 		    	if(!found) {
 		    		keys.add(key);
@@ -69,7 +69,7 @@ public abstract class AbstractSchemaService extends DefaultService implements Sc
 			} else {
 				boolean newTags = false;
 				for(Entry<String, String> tagEntry : metric.getTags().entrySet()) {
-					String key = _constructTrieKey(metric, tagEntry);
+					String key = constructTrieKey(metric, tagEntry);
 					boolean found = _trie.getValueForExactKey(key) != null;
 			    	if(!found) {
 			    		newTags = true;
@@ -96,7 +96,7 @@ public abstract class AbstractSchemaService extends DefaultService implements Sc
 	
 	protected abstract void implementationSpecificPut(List<Metric> metrics);
 
-	private String _constructTrieKey(Metric metric, Entry<String, String> tagEntry) {
+	protected String constructTrieKey(Metric metric, Entry<String, String> tagEntry) {
 		StringBuilder sb = new StringBuilder(metric.getScope());
 		sb.append('\0').append(metric.getMetric());
 		

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/schema/AbstractSchemaService.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/schema/AbstractSchemaService.java
@@ -63,7 +63,6 @@ public abstract class AbstractSchemaService extends DefaultService implements Sc
 				String key = _constructTrieKey(metric, null);
 				boolean found = _trie.getValueForExactKey(key) != null;
 		    	if(!found) {
-		    		//_trie.putIfAbsent(key, VoidValue.SINGLETON);
 		    		keys.add(key);
 		    		metricsToPut.add(metric);
 		    	}
@@ -74,7 +73,6 @@ public abstract class AbstractSchemaService extends DefaultService implements Sc
 					boolean found = _trie.getValueForExactKey(key) != null;
 			    	if(!found) {
 			    		newTags = true;
-			    		//_trie.putIfAbsent(key, VoidValue.SINGLETON);
 			    		keys.add(key);
 			    	}
 				}

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/schema/AbstractSchemaService.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/schema/AbstractSchemaService.java
@@ -56,14 +56,13 @@ public abstract class AbstractSchemaService extends DefaultService implements Sc
         //If cache is enabled, create a list of metricsToPut that do not exist on the TRIE and then call implementation 
         // specific put with only those subset of metricsToPut. 
         List<Metric> metricsToPut = new ArrayList<>(metrics.size());
-        List<String> keys = new ArrayList<>();
 		
 		for(Metric metric : metrics) {
 			if(metric.getTags().isEmpty()) {
 				String key = constructTrieKey(metric, null);
 				boolean found = _trie.getValueForExactKey(key) != null;
 		    	if(!found) {
-		    		keys.add(key);
+		    		_trie.putIfAbsent(key, VoidValue.SINGLETON);
 		    		metricsToPut.add(metric);
 		    	}
 			} else {
@@ -73,7 +72,7 @@ public abstract class AbstractSchemaService extends DefaultService implements Sc
 					boolean found = _trie.getValueForExactKey(key) != null;
 			    	if(!found) {
 			    		newTags = true;
-			    		keys.add(key);
+			    		_trie.putIfAbsent(key, VoidValue.SINGLETON);
 			    	}
 				}
 				
@@ -84,13 +83,6 @@ public abstract class AbstractSchemaService extends DefaultService implements Sc
 		}
 		
 		implementationSpecificPut(metricsToPut);
-		
-		// Add keys to the TRIE after implementationSpecificPut has finished, so that we do not unnecessarily cache 
-		// these keys if the implementationSpecificPut fails.
-		for(String key : keys) {
-			_trie.putIfAbsent(key, VoidValue.SINGLETON);
-		}
-		
 	}
 	
 	

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/schema/AbstractSchemaService.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/schema/AbstractSchemaService.java
@@ -53,16 +53,18 @@ public abstract class AbstractSchemaService extends DefaultService implements Sc
         	return;
         }
         
-        //If cache is enabled, create a list of metrics that do not exist on the trie and then call implementation 
-        // specific put with only this subset of metrics. 
+        //If cache is enabled, create a list of metricsToPut that do not exist on the TRIE and then call implementation 
+        // specific put with only those subset of metricsToPut. 
         List<Metric> metricsToPut = new ArrayList<>(metrics.size());
+        List<String> keys = new ArrayList<>();
 		
 		for(Metric metric : metrics) {
 			if(metric.getTags().isEmpty()) {
 				String key = _constructTrieKey(metric, null);
 				boolean found = _trie.getValueForExactKey(key) != null;
 		    	if(!found) {
-		    		_trie.putIfAbsent(key, VoidValue.SINGLETON);
+		    		//_trie.putIfAbsent(key, VoidValue.SINGLETON);
+		    		keys.add(key);
 		    		metricsToPut.add(metric);
 		    	}
 			} else {
@@ -72,7 +74,8 @@ public abstract class AbstractSchemaService extends DefaultService implements Sc
 					boolean found = _trie.getValueForExactKey(key) != null;
 			    	if(!found) {
 			    		newTags = true;
-			    		_trie.putIfAbsent(key, VoidValue.SINGLETON);
+			    		//_trie.putIfAbsent(key, VoidValue.SINGLETON);
+			    		keys.add(key);
 			    	}
 				}
 				
@@ -83,6 +86,13 @@ public abstract class AbstractSchemaService extends DefaultService implements Sc
 		}
 		
 		implementationSpecificPut(metricsToPut);
+		
+		// Add keys to the TRIE after implementationSpecificPut has finished, so that we do not unnecessarily cache 
+		// these keys if the implementationSpecificPut fails.
+		for(String key : keys) {
+			_trie.putIfAbsent(key, VoidValue.SINGLETON);
+		}
+		
 	}
 	
 	

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/schema/DefaultDiscoveryService.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/schema/DefaultDiscoveryService.java
@@ -121,7 +121,6 @@ public class DefaultDiscoveryService extends DefaultService implements Discovery
         requireNotDisposed();
         SystemAssert.requireArgument(query != null, "Metric query cannot be null.");
 
-        int limit = 500;
         List<MetricQuery> expandedQueryList = null;
         
         long start = System.nanoTime();
@@ -129,7 +128,9 @@ public class DefaultDiscoveryService extends DefaultService implements Discovery
         if (DiscoveryService.isWildcardQuery(query)) {
             _logger.info(MessageFormat.format("MetricQuery'{'{0}'}' contains wildcards. Will match against schema records.", query));
             
+            int limit = 10000;
             int noOfTimeseriesAllowed = DiscoveryService.maxTimeseriesAllowed(query);
+            
             if(noOfTimeseriesAllowed == 0) {
             	throw new WildcardExpansionLimitExceededException(EXCEPTION_MESSAGE);
             }
@@ -145,7 +146,7 @@ public class DefaultDiscoveryService extends DefaultService implements Discovery
 																						            			  .limit(limit)
 																						            			  .page(1)
 																						            			  .build();
-
+            	
                 while (true) {
                 	List<MetricSchemaRecord> records = _schemaService.get(schemaQuery);
                     for (MetricSchemaRecord record : records) {
@@ -168,7 +169,6 @@ public class DefaultDiscoveryService extends DefaultService implements Discovery
                         break;
                     }
                     
-                    //scanStartRow = records.get(records.size() - 1);
                     schemaQuery.setScanFrom(records.get(records.size() - 1));
                     schemaQuery.setPage(schemaQuery.getPage()+1);
                 }
@@ -195,6 +195,7 @@ public class DefaultDiscoveryService extends DefaultService implements Discovery
 
                     while (true) {
                         List<MetricSchemaRecord> records;
+                        
                         
                         if(!containsWildcard) {
                     		records = Arrays.asList(new MetricSchemaRecord(query.getNamespace(), query.getScope(), query.getMetric(), 
@@ -240,7 +241,6 @@ public class DefaultDiscoveryService extends DefaultService implements Discovery
                             break;
                         }
                         
-                        //scanStartRow = records.get(records.size() - 1);
                         schemaQuery.setScanFrom(records.get(records.size() - 1));
                         schemaQuery.setPage(schemaQuery.getPage()+1);
                         
@@ -277,7 +277,9 @@ public class DefaultDiscoveryService extends DefaultService implements Discovery
 
 	private String _getIdentifier(MetricSchemaRecord record) {
 		String identifier = new StringBuilder(record.getScope()).
+													append("$$").
 													append(record.getMetric()).
+													append("$$").
 													append(record.getNamespace()).
 													toString();
 		return identifier;

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/schema/ElasticSearchSchemaService.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/schema/ElasticSearchSchemaService.java
@@ -173,6 +173,13 @@ public class ElasticSearchSchemaService extends AbstractSchemaService {
 		
 		List<MetricSchemaRecord> records = new ArrayList<>();
 		for(Metric metric : metrics) {
+			if(metric.getTags().isEmpty()) {
+				MetricSchemaRecord msr = new MetricSchemaRecord(metric.getScope(), metric.getMetric());
+				msr.setNamespace(metric.getNamespace());
+				records.add(msr);
+				continue;
+			}
+			
 			for(Map.Entry<String, String> entry : metric.getTags().entrySet()) {
 				records.add(new MetricSchemaRecord(metric.getNamespace(), metric.getScope(), metric.getMetric(), 
 													entry.getKey(), entry.getValue()));
@@ -540,8 +547,8 @@ public class ElasticSearchSchemaService extends AbstractSchemaService {
 				}
 				
 				@Override
-				public void onFailure(Exception exception) {
-					_logger.warn("Failed while executing request", exception);
+				public void onFailure(Exception e) {
+					throw new SystemException("Failed while executing request", e);
 				}
 			};
 			

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/tsdb/AbstractTSDBService.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/tsdb/AbstractTSDBService.java
@@ -79,7 +79,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.salesforce.dva.argus.entity.Annotation;
 import com.salesforce.dva.argus.entity.Metric;

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/tsdb/DefaultTSDBService.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/tsdb/DefaultTSDBService.java
@@ -141,8 +141,7 @@ public class DefaultTSDBService extends AbstractTSDBService{
                 instrumentQueryLatency(_monitorService, entry.getKey(), queryStartExecutionTime.get(entry.getKey()), "metrics");
                 metricsMap.put(entry.getKey(), metrics);
             } catch (InterruptedException | ExecutionException e) {
-                _logger.warn("Failed to get metrics from TSDB. Reason: " + e.getMessage());
-                throw new SystemException("Failed to get metrics from TSDB. Reason: " + e.getMessage());
+                throw new SystemException("Failed to get metrics. The query was: " + entry.getKey() + "\\n", e);
             }
         }
         _logger.debug("Time to get Metrics = " + (System.currentTimeMillis() - start));

--- a/ArgusCore/src/main/javacc/MetricReader.jj
+++ b/ArgusCore/src/main/javacc/MetricReader.jj
@@ -253,16 +253,23 @@ private List<T> function(long relativeTo, boolean syntaxOnly, Class<T> clazz) :
   	List<String> constants = new ArrayList<String>();
   	String functionName, constant = "";
   	Token t = null;
+  	boolean constantsOnly = true;
 }
 {
 	functionName = functionName()
 	<LEFT_PARENTHESIS>
 		(
 		result = expression(relativeTo, syntaxOnly, clazz)
-		{ totalResult.addAll(result); }
+		{ 
+			totalResult.addAll(result);
+			constantsOnly = false;
+		}
 		| 
 		result = function(relativeTo, syntaxOnly, clazz)
-		{ totalResult.addAll(result); }
+		{ 
+			totalResult.addAll(result);
+			constantsOnly = false;
+		}
 		| 
 		t = <CONSTANT>
 			{
@@ -290,7 +297,7 @@ private List<T> function(long relativeTo, boolean syntaxOnly, Class<T> clazz) :
 		)*
 	<RIGHT_PARENTHESIS>
 	{
-	  	return evaluateFunction(functionName, totalResult, constants, relativeTo, syntaxOnly, clazz);
+	  	return evaluateFunction(functionName, totalResult, constants, relativeTo, syntaxOnly, clazz, constantsOnly);
 	}
 }
 
@@ -472,7 +479,7 @@ private String functionName() :
     { return t.image; }    
 }
 
-private List<T> evaluateFunction(String functionName, List<T> result, List<String> constants, long relativeTo, boolean syntaxOnly, Class<T> clazz) :
+private List<T> evaluateFunction(String functionName, List<T> result, List<String> constants, long relativeTo, boolean syntaxOnly, Class<T> clazz, boolean constantsOnly) :
 {}
 {
   	{
@@ -482,8 +489,11 @@ private List<T> evaluateFunction(String functionName, List<T> result, List<Strin
   	  	  	if(syntaxOnly) {
 				return (List<T>) Arrays.asList( new Metric[] { new Metric("test","metric") });
 	  	  	} else {
-	  	  	    if(TransformFactory.Function.FILL.getName().equals(functionName) && result.isEmpty()) {
-	  	  	      	constants.add(String.valueOf(relativeTo));	  	  	    }
+	  	  	    if(TransformFactory.Function.FILL.getName().equals(functionName)) {
+	  	  	    	constants.add(String.valueOf(relativeTo));
+	  	  	      	constants.add(String.valueOf(constantsOnly));
+	  	  	    }
+	  	  	    
 	  	  	  	Transform transform = factory.getTransform(functionName);
 				return (List<T>) ((constants == null || constants.isEmpty()) ? transform.transform((List<Metric>) result) : transform.transform((List<Metric>) result, constants));
 	  	  	}

--- a/ArgusCore/src/test/java/com/salesforce/dva/argus/service/metric/transform/FillTransformTest.java
+++ b/ArgusCore/src/test/java/com/salesforce/dva/argus/service/metric/transform/FillTransformTest.java
@@ -83,10 +83,12 @@ public class FillTransformTest {
         metrics.add(metric);
 
         List<String> constants = new ArrayList<String>();
-
         constants.add("1w");
         constants.add("2s");
         constants.add("100.0");
+        constants.add(System.currentTimeMillis() + "");
+        constants.add("false");
+        
         fillTransform.transform(metrics, constants);
     }
 
@@ -99,10 +101,11 @@ public class FillTransformTest {
         metrics.add(metric);
 
         List<String> constants = new ArrayList<String>();
-
         constants.add("-1s");
         constants.add("2s");
         constants.add("100.0");
+        constants.add("false");
+        
         fillTransform.transform(metrics, constants);
     }
 
@@ -115,10 +118,12 @@ public class FillTransformTest {
         metrics.add(metric);
 
         List<String> constants = new ArrayList<String>();
-
         constants.add("1s");
         constants.add("2w");
         constants.add("100.0");
+        constants.add(System.currentTimeMillis() + "");
+        constants.add("false");
+        
         fillTransform.transform(metrics, constants);
     }
 
@@ -172,6 +177,8 @@ public class FillTransformTest {
         constants.add("1s");
         constants.add("1s");
         constants.add("100.0");
+        constants.add(System.currentTimeMillis() + "");
+        constants.add("false");
 
         Map<Long, Double> expected = new HashMap<Long, Double>();
 
@@ -210,6 +217,8 @@ public class FillTransformTest {
         constants.add("2s");
         constants.add("-1s");
         constants.add("100.0");
+        constants.add(System.currentTimeMillis() + "");
+        constants.add("false");
 
         Map<Long, Double> expected = new HashMap<Long, Double>();
 
@@ -248,6 +257,8 @@ public class FillTransformTest {
         constants.add("3s");
         constants.add("-1s");
         constants.add("100.0");
+        constants.add(System.currentTimeMillis() + "");
+        constants.add("false");
 
         Map<Long, Double> expected = new HashMap<Long, Double>();
 
@@ -284,6 +295,8 @@ public class FillTransformTest {
         constants.add("100s");
         constants.add("1s");
         constants.add("100.0");
+        constants.add(System.currentTimeMillis() + "");
+        constants.add("false");
 
         Map<Long, Double> expected = new HashMap<Long, Double>();
 
@@ -330,6 +343,8 @@ public class FillTransformTest {
         constants.add("1s");
         constants.add("-1s");
         constants.add("100.0");
+        constants.add(System.currentTimeMillis() + "");
+        constants.add("false");
 
         Map<Long, Double> expected_1 = new HashMap<Long, Double>();
 
@@ -373,6 +388,8 @@ public class FillTransformTest {
         constants.add("100s");
         constants.add("1s");
         constants.add("100.0");
+        constants.add(System.currentTimeMillis() + "");
+        constants.add("false");
 
         Map<Long, Double> expected = new HashMap<Long, Double>();
 
@@ -406,6 +423,8 @@ public class FillTransformTest {
         constants.add("5m");
         constants.add("2s");
         constants.add("100.0");
+        constants.add(System.currentTimeMillis() + "");
+        constants.add("false");
 
         Map<Long, Double> expected = new HashMap<Long, Double>();
 
@@ -430,6 +449,7 @@ public class FillTransformTest {
         constants.add("1s");
         constants.add("100.0");
         constants.add(String.valueOf(System.currentTimeMillis()));
+        constants.add("true");
 
         Map<Long, Double> expected = new HashMap<Long, Double>();
 
@@ -454,6 +474,7 @@ public class FillTransformTest {
         constants.add("-1s");
         constants.add("100.0");
         constants.add(String.valueOf(System.currentTimeMillis()));
+        constants.add("true");
 
         Map<Long, Double> expected = new HashMap<Long, Double>();
 
@@ -477,6 +498,7 @@ public class FillTransformTest {
         constants.add("-1s");
         constants.add("100.0");
         constants.add(String.valueOf(System.currentTimeMillis()));
+        constants.add("true");
 
         Map<Long, Double> expected = new HashMap<Long, Double>();
 
@@ -500,6 +522,7 @@ public class FillTransformTest {
         constants.add("0s");
         constants.add("100.0");
         constants.add(String.valueOf(System.currentTimeMillis()));
+        constants.add("true");
 
         Map<Long, Double> expected = new HashMap<Long, Double>();
 
@@ -524,6 +547,7 @@ public class FillTransformTest {
         constants.add("0m");
         constants.add("100.0");
         constants.add(String.valueOf(now));
+        constants.add("true");
 
         Long expectedStartTimestamp = now - 1L * 86400L * 1000L;
         Long expectedEndTimestamp = now - 12L * 3600L * 1000L;
@@ -553,6 +577,7 @@ public class FillTransformTest {
         constants.add("0m");
         constants.add("100.0");
         constants.add(String.valueOf(now));
+        constants.add("true");
         
         Long expectedStartTimestamp = now - 7L * 86400L * 1000L;
         Long expectedEndTimestamp = now - 0L * 60L * 1000L;
@@ -580,6 +605,7 @@ public class FillTransformTest {
         constants.add("0m");
         constants.add("100.0");
         constants.add(String.valueOf(System.currentTimeMillis()));
+        constants.add("true");
 
         Long expectedStartTimestamp = System.currentTimeMillis() - 1L * 86400L * 1000L;
         Long expectedEndTimestamp = System.currentTimeMillis();
@@ -595,5 +621,38 @@ public class FillTransformTest {
         assertEquals(true, timestampSet[timestampSet.length - 1] - expectedEndTimestamp <= 1000L);
         assertEquals(new HashSet<Double>(Arrays.asList(100.0)), new HashSet<Double>(result.get(0).getDatapoints().values()));
     }
+    
+    @Test
+    public void testFillTransform_MetricWithEmptyDatapointsMap() {
+    	Transform fillTransform = new FillTransform();
+    	List<String> constants = new ArrayList<>();
+    	
+    	Metric m = new Metric("scope", "metric");
+    	
+    	constants.add("100s");
+        constants.add("1s");
+        constants.add("100.0");
+        constants.add(System.currentTimeMillis() + "");
+        constants.add("false");
+        
+        List<Metric> metrics = fillTransform.transform(Arrays.asList(m), constants);
+    	assertEquals(metrics.size(), 1);
+    }
+    
+    @Test
+    public void testFillTransform_EmptyMetricsList() {
+    	Transform fillTransform = new FillTransform();
+    	List<String> constants = new ArrayList<>();
+    	
+    	constants.add("100s");
+        constants.add("1s");
+        constants.add("100.0");
+        constants.add(System.currentTimeMillis() + "");
+        constants.add("false");
+        
+        List<Metric> metrics = fillTransform.transform(Arrays.asList(), constants);
+    	assertEquals(metrics.size(), 0);
+    }
+    
 }
 /* Copyright (c) 2016, Salesforce.com, Inc.  All rights reserved. */

--- a/ArgusWebServices/src/main/java/com/salesforce/dva/argus/ws/resources/DashboardResources.java
+++ b/ArgusWebServices/src/main/java/com/salesforce/dva/argus/ws/resources/DashboardResources.java
@@ -31,12 +31,10 @@
 
 package com.salesforce.dva.argus.ws.resources;
 
-import com.salesforce.dva.argus.entity.Alert;
 import com.salesforce.dva.argus.entity.Dashboard;
 import com.salesforce.dva.argus.entity.PrincipalUser;
 import com.salesforce.dva.argus.service.DashboardService;
 import com.salesforce.dva.argus.ws.annotation.Description;
-import com.salesforce.dva.argus.ws.dto.AlertDto;
 import com.salesforce.dva.argus.ws.dto.DashboardDto;
 import com.salesforce.dva.argus.ws.listeners.ArgusWebServletListener;
 import java.math.BigInteger;


### PR DESCRIPTION
PR contains following changes:
- FILL Transform bug fix when a metric expression returns empty datapoint set. Also add the ability to distinguish between FILL(expr, #constants#) and FILL(#constants#) by adding a constantsOnly flag
-  Cleanup ESSchemaService exception handling and logging. Also remove records from TRIE if an exception occurs while indexing schema records
- Increase DefaultDiscoveryService schema records fetch size from 500 to 10000. 