### PR TITLE
Automatic deploy improvements

### DIFF
--- a/.travis.deploy.sh
+++ b/.travis.deploy.sh
@@ -1,7 +1,16 @@
 #!/usr/bin/env bash
+# Import code signing keys
+# TODO: NEED IDs FOR THE KEYS AND IV!!!
+openssl aes-256-cbc -K $encrypted_ID_key -iv $encrypted_ID_iv -in codesigning.asc.enc -out codesigning.asc -d
+gpg --fast-import codesigning.asc
+
+# Remove code signing keys for cleanliness
+rm codesigning.asc
+
 cp .travis.settings.xml $HOME/.m2/settings.xml
 # PROJECT_VERSION in the commands below should be incremented and sourced from project.version
 source project.version
 # Builds top level pom w/ zip
+mvn versions:set -DnewVersion=${PROJECT_VERSION}
 mvn --batch-mode --non-recursive -DskipTests -DskipDockerBuild -U -Prelease -Dproject.version=${PROJECT_VERSION} clean install
 mvn --batch-mode -DskipDockerBuild -DskipTests -Dproject.version=${PROJECT_VERSION} -Prelease clean deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,16 @@ addons:
     build_command_prepend: "mvn clean"
     build_command:   "mvn -DskipTests=true install"
     branch_pattern: master
+cache:
+  directories:
+  - $HOME/.m2/repository
 before_script:
   - pip install --user codecov
 after_success:
   - codecov
 deploy:
   provider: script
-  script: ./travis.deploy.sh
+  script: sh $TRAVIS_BUILD_DIR/.travis.deploy.sh
   skip_cleanup: true
   on:
     branch: master

--- a/pom.xml
+++ b/pom.xml
@@ -342,7 +342,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.7</version>
+                        <version>1.6.8</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>
@@ -373,7 +373,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.10.4</version>
+                        <version>3.0.0</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>


### PR DESCRIPTION
# Net result after this PR and the remaining changes below
After this PR, along with the additional steps that need to be completed below, the following will be how your automatic deployments to Maven Central work:

* A single branch should be selected as your release branch. It is currently set up as `master` for both code coverage and release (see notes in Remaining Changes)
* In that branch, your Maven version will be set based on what is set up as `PROJECT_VERSION` in the `project.version` file. (This was added in this PR to make sure that the artifacts in Maven Central carry the proper version in the `pom.xml`.)
* Your code will be signed, javadoc created, and all artifacts and source will be sent to Sonatype OSS Nexus
* Your staging profile will automatically be closed, triggering a final release to Maven Central.

# Remaining changes
There are a few changes remaining:

## Decide on a branch that will be used for automatic releases
Based on the current configuration, your release branch is set up as `master` for both `Coverity` code coverage as well as for the deployment operations. Since none of these changes have made it to master, the automatic deployment has not run. You'll need to do everything in this PR for this to work properly. You also already have branch protections set up on `master` and `develop` so that a random person can't push a malicious change to Maven Central.

## Need to get GPG signing set up in Travis
1. Need to do a `travis login`
2. Get `GPG_KEY_NAME` encrypted and added to `.travis.yml`
    * `travis encrypt GPG_KEY_NAME=name_of_your_key --add`
3. Get `GPG_PASSPHRASE ` encrypted and added to `.travis.yml`
    * `travis encrypt GPG_PASSPHRASE=your_passphrase --add`
4. Get `codesigning.asc` encrypted and into git as `codesigning.asc.enc`
    1. Make sure that gpg only has your subkey (and not your master key). [This article](http://www.debonair.io/post/maven-cd/) discusses the subject fairly thoroughly. I believe it was somewhat part of the model for your original setup (and still mostly the same as what I've set up here with some differences in Travis for modernization).
    2. Using the e-mail associated with your key (replace it in the command below!) and after you have ensured that you only have the signing subkey, do:
        1. `gpg --export --armor your@email.com > codesigning.asc`
        2. `gpg --export-secret-keys --armor your@email.com >> codesigning.asc`
        3. `travis encrypt-file codesigning.asc` - encrypt the file (will create `codesigning.asc.enc`)
            * IMPORTANT: Watch the output of this and keep track of the the `openssl aes-256-cbc -K ...` command. You'll use a key from that to update a similar line in `.travis.deploy.sh` after `-K` and `-iv`.
        4. `shred --remove codesigning.asc` - shred the unencrypted secret file
        5. Update `.travis.deploy.sh` on line 4 with the correct `$encrypted_ID_key` and `$encrypted_ID_iv` from step 3.
        6. Check in `codesigning.asc.enc` in the root of the repo and your changes to `.travis.deploy.sh`.