### PR TITLE
Add ag-compute control.

### DIFF
--- a/ArgusWeb/app/js/argus.js
+++ b/ArgusWeb/app/js/argus.js
@@ -41,6 +41,7 @@ angular.module('argus', [
 	'argus.directives.breadcrumbs',
 	'argus.directives.confirm',
 	'argus.directives.dashboardResource',
+	'argus.directives.controls.compute',
 	'argus.directives.controls.dashboard',
 	'argus.directives.controls.date',
 	'argus.directives.controls.submit',
@@ -207,6 +208,7 @@ require('./directives/tableList');
 require('./directives/tableTabs');
 require('./directives/breadcrumbs');
 require('./directives/dashboardResource');
+require('./directives/controls/compute');
 require('./directives/controls/dashboard');
 require('./directives/controls/date');
 require('./directives/controls/submit');

--- a/ArgusWeb/app/js/directives/controls/compute.js
+++ b/ArgusWeb/app/js/directives/controls/compute.js
@@ -1,0 +1,41 @@
+'use strict';
+/*global angular:false */
+
+angular.module('argus.directives.controls.compute', [])
+.directive('agCompute', ['CONFIG', '$routeParams', '$interpolate', function(CONFIG, $routeParams, $interpolate) {
+	var refreshControl = function(scope, expression, control, dashboardCtrl) {
+		if (control['name'] === scope.controlName) {
+			return;
+		}
+
+		var controlsMap = {};
+		dashboardCtrl.getAllControls().forEach(function(c) {
+			controlsMap[c['name']] = c['value'];
+		});
+
+		var newValue = $interpolate(expression)(controlsMap);
+		if (newValue !== controlsMap[scope.controlName]) {
+			dashboardCtrl.updateControl(scope.controlName, newValue, 'agCompute');
+		}
+	};
+
+	return {
+		restrict: 'E',
+		scope: {
+			controlName: '@name',
+			elemId: '@id'
+		},
+		terminal: true,
+		priority: 1000,
+		require: '^agDashboard',
+		link: function(scope, element, attributes, dashboardCtrl) {
+			element.hide();
+
+			scope.$on(dashboardCtrl.getControlChangeEventName(), function(evt, control) {
+				refreshControl(scope, element.text(), control, dashboardCtrl)
+			});
+
+			refreshControl(scope, element.text(), {}, dashboardCtrl);
+		}
+	};
+}]);

--- a/ArgusWeb/app/js/directives/controls/dashboard.js
+++ b/ArgusWeb/app/js/directives/controls/dashboard.js
@@ -15,6 +15,11 @@ angular.module('argus.directives.controls.dashboard', [])
 
 			this.updateControl = function(controlName, controlValue, controlType, localSubmit) {
 				var controlExists = false;
+				var control = {
+					name: controlName,
+					value: controlValue,
+					type: controlType
+				};
 
 				if (!localSubmit) {
 					for (var prop in $routeParams) {
@@ -33,16 +38,14 @@ angular.module('argus.directives.controls.dashboard', [])
 				}
 
 				if (!controlExists) {
-					var control = {
-						name: controlName,
-						value: controlValue,
-						type: controlType
-					};
 					$scope.controls.push(control);
 				}
 
 				//add controls to url
 				this.addControlsToUrl();
+
+				// broadcast update
+				this.broadcastEvent(this.getControlChangeEventName(), control);
 			};
 
 			this.addControlsToUrl = function () {
@@ -58,6 +61,10 @@ angular.module('argus.directives.controls.dashboard', [])
 
 			this.getSubmitBtnEventName = function(){
 				return 'submitButtonEvent';
+			};
+
+			this.getControlChangeEventName = function() {
+				return 'updateControl';
 			};
 
 			this.broadcastEvent = function(eventName, data){


### PR DESCRIPTION
This is an invisible control, it can watch for a value from another
control and apply some transformation to it.

Scenario:

The same text is used in different parts of a metric name but
in some cases it should be in upper case and in some cases it should
be in lower case. For example we query a metric: `some.namespace.FOO:metric.name-foo`

To build an expression we can define 2 parameters: `my_param` is a dropdown in uppercase and `my_param_ls` is an invisible compute parameter. It takes value of the `my_param` and 
converts it to a lower case:

```
<ag-select name="my_param" label="Very important parameter" default='FOO'>
  <option value="FOO">FOO</option>
  <option value="BAR">BAR</option>
  <option value="BAZ">BAZ</option>
</ag-select>
<ag-compute name="my_param_lc">{{my_param | lowercase}}</ag-compute>
```

and later both of the parameters can be applied to a metric expression:

```
$start$:$end$:some.namespace.$my_param$:metric.name-$my_param_lc$:avg
```