### PR TITLE
Print number in a status indicator as a string formatted according to a current locale. Helps to read big numbers

### DIFF
--- a/ArgusWeb/app/js/services/charts/chartRendering.js
+++ b/ArgusWeb/app/js/services/charts/chartRendering.js
@@ -82,6 +82,9 @@ angular.module('argus.services.charts.rendering', [])
 
 			// show numerical value if set
 			if (showNum) {
+				if (lastStatusVal !== undefined) {
+					lastStatusVal = lastStatusValNum.toLocaleString();
+				}
 				$('#' + UtilService.cssNotationCharactersConverter(attributes.name) + '-numVal').removeClass('hide').addClass('inlineBlock').html(lastStatusVal);
 			}
 


### PR DESCRIPTION
This is a small fix, but I found that status indicator with a visible number field is more readable with this formatting on values > 1000 and especially on numbers > 1M