### PR TITLE
Switch from source -> .

### DIFF
--- a/.travis.deploy.sh
+++ b/.travis.deploy.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 # Generate & push code signing keys to keyserver.ubuntu.com, source into environment
-source ${TRAVIS_BUILD_DIR}/.travis.gpg.sh
+. ${TRAVIS_BUILD_DIR}/.travis.gpg.sh
 
 set -ex
 # Utilize tokenized `.travis.settings.xml` to do deployment
 cp ${TRAVIS_BUILD_DIR}/.travis.settings.xml ${HOME}/.m2/settings.xml
 
 # PROJECT_VERSION in the commands below should be incremented and sourced from project.version
-source ${TRAVIS_BUILD_DIR}/project.version
+. ${TRAVIS_BUILD_DIR}/project.version
 
 # Set the version of all `pom.xml`s to ${PROJECT_VERSION} from the `project.version` file
 echo "Setting Maven version to ${PROJECT_VERSION}"


### PR DESCRIPTION
@dilipdevaraj-sfdc This fixes the issue where .travis.deploy.sh couldn't properly source other scripts/files. I tested this out in a separate repo here: https://github.com/justinharringa/travis-source/commits/master