### PR TITLE
Javadoc required turn off docker deploy

### DIFF
--- a/.travis.deploy.sh
+++ b/.travis.deploy.sh
@@ -13,5 +13,5 @@ cp ${TRAVIS_BUILD_DIR}/.travis.settings.xml ${HOME}/.m2/settings.xml
 echo "Setting Maven version to ${PROJECT_VERSION}"
 mvn versions:set -DnewVersion=${PROJECT_VERSION}
 # Builds top level pom w/ zip
-mvn --batch-mode --non-recursive -DskipTests -DskipDockerBuild -U -Prelease -Dproject.version=${PROJECT_VERSION} clean install
-mvn --batch-mode -DskipDockerBuild -DskipTests -Dproject.version=${PROJECT_VERSION} -Prelease clean deploy
+mvn --batch-mode --non-recursive -Dmaven.javadoc.skip=true -DskipTests -DskipDockerBuild -U -Prelease -Dproject.version=${PROJECT_VERSION} clean install
+mvn --batch-mode -Dmaven.javadoc.skip=true -DskipDockerBuild -DskipTests -Dproject.version=${PROJECT_VERSION} -Prelease clean deploy

--- a/.travis.deploy.sh
+++ b/.travis.deploy.sh
@@ -13,5 +13,5 @@ cp ${TRAVIS_BUILD_DIR}/.travis.settings.xml ${HOME}/.m2/settings.xml
 echo "Setting Maven version to ${PROJECT_VERSION}"
 mvn versions:set -DnewVersion=${PROJECT_VERSION}
 # Builds top level pom w/ zip
-mvn --batch-mode --non-recursive -Dmaven.javadoc.skip=true -DskipTests -DskipDockerBuild -U -Prelease -Dproject.version=${PROJECT_VERSION} clean install
-mvn --batch-mode -Dmaven.javadoc.skip=true -DskipDockerBuild -DskipTests -Dproject.version=${PROJECT_VERSION} -Prelease clean deploy
+mvn --batch-mode --non-recursive -DskipTests -DskipDocker -U -Prelease -Dproject.version=${PROJECT_VERSION} clean install
+mvn --batch-mode -DskipDocker -DskipTests -Dproject.version=${PROJECT_VERSION} -Prelease clean deploy


### PR DESCRIPTION
Javadoc is required for pushing to [Maven Central](https://central.sonatype.org/pages/requirements.html). 

[Skip all docker goals](https://github.com/spotify/docker-maven-plugin#bind-docker-commands-to-maven-phases) to disable push to docker.io. There are currently no credentials set up to push the docker images so this stops pushing to avoid failure when pushing to docker.io.

Note also that the [docker-maven-plugin has been deprecated](https://github.com/spotify/docker-maven-plugin#status-bug-fix-only)

(includes 60a8122 to remove javadoc generation to avoid merge conflicts in release branch and master)