### PR TITLE
Add new scopenames index with scope and mts field

### DIFF
--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/entity/ScopeOnlySchemaRecord.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/entity/ScopeOnlySchemaRecord.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2016, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.salesforce.dva.argus.entity;
+
+import java.text.MessageFormat;
+
+/**
+ * Represents a search result row for scope names discovery queries.
+ *
+ * @author  Dilip Devaraj (ddevaraj@salesforce.com)
+ */
+public class ScopeOnlySchemaRecord {
+
+	//~ Instance fields ******************************************************************************************************************************
+
+	private String scope;
+
+	//~ Constructors *********************************************************************************************************************************
+
+	/** Creates a new ScopeOnlySchemaRecord object. */
+	public ScopeOnlySchemaRecord() { }
+
+
+	/**
+	 * Creates a new ScopeOnlySchemaRecord object.
+	 *
+	 * @param  scope      The metric schema scope.
+	 */
+	public ScopeOnlySchemaRecord(String scope) {
+		setScope(scope);
+	}
+
+	/**
+	 * Indicates the scope associated with the result.
+	 *
+	 * @return  The scope.  Can be null or empty.
+	 */
+	public String getScope() {
+		return scope;
+	}
+
+	/**
+	 * Specifies the scope associated with the result.
+	 *
+	 * @param  scope  The scope.  Can be null or empty.
+	 */
+	public void setScope(String scope) { 
+		this.scope = scope;
+	}
+
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+
+		result = prime * result + ((scope == null) ? 0 : scope.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+
+		ScopeOnlySchemaRecord other = (ScopeOnlySchemaRecord) obj;
+
+		if (scope == null) {
+			if (other.scope != null) {
+				return false;
+			}
+		} else if (!scope.equals(other.scope)) {
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return MessageFormat.format("ScopeOnlySchemaRecord = (Scope = {0}", scope);
+	}
+
+	public static String print(ScopeOnlySchemaRecord msr) {
+		StringBuilder sb = new StringBuilder(msr.getScope());
+		return sb.toString();
+	}
+}
+/* Copyright (c) 2016, Salesforce.com, Inc.  All rights reserved. */

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/MonitorService.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/MonitorService.java
@@ -207,6 +207,8 @@ public interface MonitorService extends Service {
         SCHEMACOMMIT_CLIENT_METRIC_WRITES("argus.core", "schemacommit.client.metric.writes"),
     	SCHEMARECORDS_WRITTEN("argus.core", "schemarecords.written"),
     	SCHEMARECORDS_WRITE_LATENCY("argus.core", "schemarecords.write.latency"),
+    	SCOPENAMES_WRITTEN("argus.core", "scopenames.written"),
+    	SCOPENAMES_WRITE_LATENCY("argus.core", "scopenames.write.latency"),    	
     	SCHEMARECORDS_QUERY_COUNT("argus.core", "schemarecords.query.count"),
     	SCHEMARECORDS_QUERY_LATENCY("argus.core", "schemarecords.query.latency");
 

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/schema/AbstractSchemaService.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/schema/AbstractSchemaService.java
@@ -27,15 +27,28 @@ import com.salesforce.dva.argus.service.SchemaService;
 import com.salesforce.dva.argus.system.SystemAssert;
 import com.salesforce.dva.argus.system.SystemConfiguration;
 
+/**
+ * Implementation of the abstract schema service class
+ *
+ * @author  Dilip Devaraj (ddevaraj@salesforce.com)
+ */
 public abstract class AbstractSchemaService extends DefaultService implements SchemaService {
 	private static final long POLL_INTERVAL_MS = 10 * 60 * 1000L;
 	private static final int DAY_IN_SECONDS = 24 * 60 * 60;
 	private static final int HOUR_IN_SECONDS = 60 * 60;
+
+	/* Have two separate bloom filters one for metrics schema and another for scope names schema.
+	 * Since scopes will continue to repeat more often on subsequent kafka batch reads, we can easily check this from the  bloom filter for scopes only. 
+	 * Hence we can avoid the extra call to populate scopenames index on ES in subsequent Kafka reads.
+	 */
 	protected static BloomFilter<CharSequence> bloomFilter;
+	protected static BloomFilter<CharSequence> bloomFilterScopeOnly;
 	private Random rand = new Random();
 	private int randomNumber = rand.nextInt();
 	private int bloomFilterExpectedNumberInsertions;
 	private double bloomFilterErrorRate;
+	private int bloomFilterScopeOnlyExpectedNumberInsertions;
+	private double bloomFilterScopeOnlyErrorRate;	
 	private final Logger _logger = LoggerFactory.getLogger(getClass());
 	private final Thread _bloomFilterMonitorThread;
 	protected final boolean _syncPut;
@@ -49,7 +62,12 @@ public abstract class AbstractSchemaService extends DefaultService implements Sc
 				Property.BLOOMFILTER_EXPECTED_NUMBER_INSERTIONS.getDefaultValue()));
 		bloomFilterErrorRate = Double.parseDouble(config.getValue(Property.BLOOMFILTER_ERROR_RATE.getName(), 
 				Property.BLOOMFILTER_ERROR_RATE.getDefaultValue()));
+		bloomFilterScopeOnlyExpectedNumberInsertions = Integer.parseInt(config.getValue(Property.BLOOMFILTER_SCOPE_ONLY_EXPECTED_NUMBER_INSERTIONS.getName(), 
+				Property.BLOOMFILTER_SCOPE_ONLY_EXPECTED_NUMBER_INSERTIONS.getDefaultValue()));
+		bloomFilterScopeOnlyErrorRate = Double.parseDouble(config.getValue(Property.BLOOMFILTER_SCOPE_ONLY_ERROR_RATE.getName(), 
+				Property.BLOOMFILTER_SCOPE_ONLY_ERROR_RATE.getDefaultValue()));
 		bloomFilter = BloomFilter.create(Funnels.stringFunnel(Charset.defaultCharset()), bloomFilterExpectedNumberInsertions , bloomFilterErrorRate);
+		bloomFilterScopeOnly = BloomFilter.create(Funnels.stringFunnel(Charset.defaultCharset()), bloomFilterScopeOnlyExpectedNumberInsertions , bloomFilterScopeOnlyErrorRate);
 
 		_syncPut = Boolean.parseBoolean(
 				config.getValue(Property.SYNC_PUT.getName(), Property.SYNC_PUT.getDefaultValue()));
@@ -66,7 +84,6 @@ public abstract class AbstractSchemaService extends DefaultService implements Sc
 	public void put(Metric metric) {
 		requireNotDisposed();
 		SystemAssert.requireArgument(metric != null, "Metric cannot be null.");
-
 		put(Arrays.asList(metric));
 	}
 
@@ -78,15 +95,19 @@ public abstract class AbstractSchemaService extends DefaultService implements Sc
 		// Create a list of metricsToPut that do not exist on the BLOOMFILTER and then call implementation 
 		// specific put with only those subset of metricsToPut. 
 		List<Metric> metricsToPut = new ArrayList<>(metrics.size());
+		List<String> scopesToPut = new ArrayList<>(metrics.size());
 
 		for(Metric metric : metrics) {
+			// check metric schema bloom filter
 			if(metric.getTags().isEmpty()) {
+				// if metric does not have tags
 				String key = constructKey(metric, null);
 				boolean found = bloomFilter.mightContain(key);
 				if(!found) {
 					metricsToPut.add(metric);
 				}
 			} else {
+				// if metric has tags
 				boolean newTags = false;
 				for(Entry<String, String> tagEntry : metric.getTags().entrySet()) {
 					String key = constructKey(metric, tagEntry);
@@ -100,12 +121,25 @@ public abstract class AbstractSchemaService extends DefaultService implements Sc
 					metricsToPut.add(metric);
 				}
 			}
+
+			// Check scope only bloom filter
+			String key = constructScopeOnlyKey(metric);
+			boolean found = bloomFilterScopeOnly.mightContain(key);
+			if(!found) {
+				scopesToPut.add(metric.getScope());
+			}			
 		}
 
-		implementationSpecificPut(metricsToPut);
+		implementationSpecificPut(metricsToPut, scopesToPut);
 	}
 
-	protected abstract void implementationSpecificPut(List<Metric> metrics);
+	/*
+	 * Calls the implementation specific write for indexing the records
+	 *
+	 * @param  metrics    The metrics metadata that will be written to a separate index.
+	 * @param  scopeNames The scope names that that will be written to a separate index.
+	 */
+	protected abstract void implementationSpecificPut(List<Metric> metrics, List<String> scopeNames);
 
 	@Override
 	public void dispose() {
@@ -181,6 +215,26 @@ public abstract class AbstractSchemaService extends DefaultService implements Sc
 		return sb.toString();
 	}
 
+	protected String constructScopeOnlyKey(Metric metric) {
+		StringBuilder sb = new StringBuilder(metric.getScope());
+
+		// Add randomness for each instance of bloom filter running on different 
+		// schema clients to reduce probability of false positives that metric schemas are not written to ES
+		sb.append('\0').append(randomNumber);
+
+		return sb.toString();
+	}
+
+	protected String constructScopeOnlyKey(String scope) {
+		StringBuilder sb = new StringBuilder(scope);
+
+		// Add randomness for each instance of bloom filter running on different 
+		// schema clients to reduce probability of false positives that metric schemas are not written to ES
+		sb.append('\0').append(randomNumber);
+
+		return sb.toString();
+	}
+
 	private void createScheduledExecutorService(int targetHourToStartAt){
 		scheduledExecutorService = Executors.newScheduledThreadPool(1);
 		int initialDelayInSeconds = getNumHoursUntilTargetHour(targetHourToStartAt) * HOUR_IN_SECONDS;
@@ -215,6 +269,8 @@ public abstract class AbstractSchemaService extends DefaultService implements Sc
 		SYNC_PUT("service.property.schema.sync.put", "false"),
 		BLOOMFILTER_EXPECTED_NUMBER_INSERTIONS("service.property.schema.bloomfilter.expected.number.insertions", "40"),
 		BLOOMFILTER_ERROR_RATE("service.property.schema.bloomfilter.error.rate", "0.00001"),
+		BLOOMFILTER_SCOPE_ONLY_EXPECTED_NUMBER_INSERTIONS("service.property.schema.bloomfilter.scope.only.expected.number.insertions", "40"),
+		BLOOMFILTER_SCOPE_ONLY_ERROR_RATE("service.property.schema.bloomfilter.scope.only.error.rate", "0.00001"),
 		/*
 		 *  Have a different configured flush start hour for different machines to prevent thundering herd problem. 
 		 */
@@ -272,8 +328,10 @@ public abstract class AbstractSchemaService extends DefaultService implements Sc
 		}
 
 		private void _checkBloomFilterUsage() {
-			_logger.info("Bloom approx no. elements = {}", bloomFilter.approximateElementCount());
-			_logger.info("Bloom expected error rate = {}", bloomFilter.expectedFpp());
+			_logger.info("Metrics Bloom approx no. elements = {}", bloomFilter.approximateElementCount());
+			_logger.info("Metrics Bloom expected error rate = {}", bloomFilter.expectedFpp());
+			_logger.info("Scope only Bloom approx no. elements = {}", bloomFilterScopeOnly.approximateElementCount());
+			_logger.info("Scope only Bloom expected error rate = {}", bloomFilterScopeOnly.expectedFpp());			
 		}
 
 		private void _sleepForPollPeriod() {
@@ -300,6 +358,7 @@ public abstract class AbstractSchemaService extends DefaultService implements Sc
 		private void _flushBloomFilter() {
 			_logger.info("Flushing out bloom filter entries");
 			bloomFilter = BloomFilter.create(Funnels.stringFunnel(Charset.defaultCharset()), bloomFilterExpectedNumberInsertions , bloomFilterErrorRate);
+			bloomFilterScopeOnly = BloomFilter.create(Funnels.stringFunnel(Charset.defaultCharset()), bloomFilterScopeOnlyExpectedNumberInsertions , bloomFilterScopeOnlyErrorRate);
 			/* Don't need explicit synchronization to prevent slowness majority of the time*/
 			randomNumber = rand.nextInt();
 		}

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/schema/AbstractSchemaService.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/schema/AbstractSchemaService.java
@@ -123,7 +123,7 @@ public abstract class AbstractSchemaService extends DefaultService implements Sc
 			}
 
 			// Check scope only bloom filter
-			String key = constructScopeOnlyKey(metric);
+			String key = constructScopeOnlyKey(metric.getScope());
 			boolean found = bloomFilterScopeOnly.mightContain(key);
 			if(!found) {
 				scopesToPut.add(metric.getScope());
@@ -207,16 +207,6 @@ public abstract class AbstractSchemaService extends DefaultService implements Sc
 		if(tagv != null) {
 			sb.append('\0').append(tagv);
 		}
-
-		// Add randomness for each instance of bloom filter running on different 
-		// schema clients to reduce probability of false positives that metric schemas are not written to ES
-		sb.append('\0').append(randomNumber);
-
-		return sb.toString();
-	}
-
-	protected String constructScopeOnlyKey(Metric metric) {
-		StringBuilder sb = new StringBuilder(metric.getScope());
 
 		// Add randomness for each instance of bloom filter running on different 
 		// schema clients to reduce probability of false positives that metric schemas are not written to ES

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/schema/AsyncHbaseSchemaService.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/schema/AsyncHbaseSchemaService.java
@@ -192,7 +192,7 @@ public class AsyncHbaseSchemaService extends AbstractSchemaService {
     //~ Methods **************************************************************************************************************************************
 
     @Override
-    protected void implementationSpecificPut(List<Metric> metrics) {
+    protected void implementationSpecificPut(List<Metric> metrics, List<String> scopeNames) {
         requireNotDisposed();
         SystemAssert.requireArgument(metrics != null, "Metric list cannot be null.");
         

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/schema/ElasticSearchSchemaService.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/schema/ElasticSearchSchemaService.java
@@ -683,7 +683,7 @@ public class ElasticSearchSchemaService extends AbstractSchemaService {
 				List<ScopeOnlySchemaRecord> recordsToRemove = new ArrayList<>();
 				for(Item item : putResponse.items) {
 					if(item.create != null && item.create.status != HttpStatus.SC_CONFLICT && item.create.status != HttpStatus.SC_CREATED) {
-						_logger.warn("Failed to index metric. Reason: " + new ObjectMapper().writeValueAsString(item.create.error));
+						_logger.warn("Failed to index scope. Reason: " + new ObjectMapper().writeValueAsString(item.create.error));
 						recordsToRemove.add(scopeOnlySchemaRecordList.getRecord(item.create._id));
 					}
 
@@ -733,10 +733,10 @@ public class ElasticSearchSchemaService extends AbstractSchemaService {
 
 	protected void _addToBloomFilterScopeOnly(List<ScopeOnlySchemaRecord> records){
 		_logger.info("Adding {} records into scope only bloom filter.", records.size());
-		for(ScopeOnlySchemaRecord record : records) {		
-			String key = constructScopeOnlyKey(record.getScope());		
-			bloomFilter.put(key);		
-		}		
+		for(ScopeOnlySchemaRecord record : records) {
+			String key = constructScopeOnlyKey(record.getScope());
+			bloomFilterScopeOnly.put(key);
+		}
 	}
 
 	private String _constructTermAggregationQuery(MetricSchemaRecordQuery query, RecordType type) {
@@ -1044,6 +1044,7 @@ public class ElasticSearchSchemaService extends AbstractSchemaService {
 		propertiesNode.put(RecordType.SCOPE.getName(), _createFieldNode(FIELD_TYPE_TEXT));
 
 		propertiesNode.put("mts", _createFieldNodeNoAnalyzer(FIELD_TYPE_DATE));
+		propertiesNode.put("cts", _createFieldNodeNoAnalyzer(FIELD_TYPE_DATE));
 
 		ObjectNode typeNode = mapper.createObjectNode();
 		typeNode.put("properties", propertiesNode);

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/schema/ElasticSearchSchemaService.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/schema/ElasticSearchSchemaService.java
@@ -26,7 +26,6 @@ import org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager;
 import org.apache.http.impl.nio.reactor.DefaultConnectingIOReactor;
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Response;
-import org.elasticsearch.client.ResponseListener;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.client.RestClientBuilder.HttpClientConfigCallback;
@@ -49,9 +48,11 @@ import com.salesforce.dva.argus.entity.KeywordQuery;
 import com.salesforce.dva.argus.entity.Metric;
 import com.salesforce.dva.argus.entity.MetricSchemaRecord;
 import com.salesforce.dva.argus.entity.MetricSchemaRecordQuery;
+import com.salesforce.dva.argus.entity.ScopeOnlySchemaRecord;
 import com.salesforce.dva.argus.service.MonitorService;
 import com.salesforce.dva.argus.service.MonitorService.Counter;
 import com.salesforce.dva.argus.service.SchemaService;
+import com.salesforce.dva.argus.service.schema.AsyncHbaseSchemaService.Property;
 import com.salesforce.dva.argus.service.schema.ElasticSearchSchemaService.PutResponse.Item;
 import com.salesforce.dva.argus.service.schema.MetricSchemaRecordList.HashAlgorithm;
 import com.salesforce.dva.argus.system.SystemAssert;
@@ -66,6 +67,8 @@ import com.salesforce.dva.argus.system.SystemException;
 @Singleton
 public class ElasticSearchSchemaService extends AbstractSchemaService {
 
+	private static String SCOPE_INDEX_NAME;
+	private static String SCOPE_TYPE_NAME;
 	private static final String INDEX_NAME = "metadata_index";
 	private static final String TYPE_NAME = "metadata_type";
 	private static final String KEEP_SCROLL_CONTEXT_OPEN_FOR = "1m";
@@ -75,11 +78,15 @@ public class ElasticSearchSchemaService extends AbstractSchemaService {
 	private static final String FIELD_TYPE_DATE ="date";
 
 	private final ObjectMapper _mapper;
+	private final ObjectMapper _scopeOnlyMapper;
+
 	private Logger _logger = LoggerFactory.getLogger(getClass());
 	private final MonitorService _monitorService;
 	private final RestClient _esRestClient;
 	private final int _replicationFactor;
 	private final int _numShards;
+	private final int _replicationFactorForScopeIndex;
+	private final int _numShardsForScopeIndex;	
 	private final int _bulkIndexingSize;
 	private HashAlgorithm _idgenHashAlgo;
 
@@ -89,7 +96,12 @@ public class ElasticSearchSchemaService extends AbstractSchemaService {
 
 		_monitorService = monitorService;
 		_mapper = _createObjectMapper();
+		_scopeOnlyMapper = _createScopeOnlyObjectMapper();
 
+		SCOPE_INDEX_NAME = config.getValue(Property.ELASTICSEARCH_SCOPE_INDEX_NAME.getName(), 
+				Property.ELASTICSEARCH_SCOPE_INDEX_NAME.getDefaultValue());
+		SCOPE_TYPE_NAME = config.getValue(Property.ELASTICSEARCH_SCOPE_TYPE_NAME.getName(), 
+				Property.ELASTICSEARCH_SCOPE_TYPE_NAME.getDefaultValue());
 		String algorithm = config.getValue(Property.ELASTICSEARCH_IDGEN_HASH_ALGO.getName(), Property.ELASTICSEARCH_IDGEN_HASH_ALGO.getDefaultValue());
 		try {
 			_idgenHashAlgo = HashAlgorithm.fromString(algorithm);
@@ -105,6 +117,12 @@ public class ElasticSearchSchemaService extends AbstractSchemaService {
 
 		_numShards = Integer.parseInt(
 				config.getValue(Property.ELASTICSEARCH_SHARDS_COUNT.getName(), Property.ELASTICSEARCH_SHARDS_COUNT.getDefaultValue()));
+
+		_replicationFactorForScopeIndex = Integer.parseInt(
+				config.getValue(Property.ELASTICSEARCH_NUM_REPLICAS_FOR_SCOPE_INDEX.getName(), Property.ELASTICSEARCH_NUM_REPLICAS_FOR_SCOPE_INDEX.getDefaultValue()));
+
+		_numShardsForScopeIndex = Integer.parseInt(
+				config.getValue(Property.ELASTICSEARCH_SHARDS_COUNT_FOR_SCOPE_INDEX.getName(), Property.ELASTICSEARCH_SHARDS_COUNT_FOR_SCOPE_INDEX.getDefaultValue()));
 
 		_bulkIndexingSize = Integer.parseInt(
 				config.getValue(Property.ELASTICSEARCH_INDEXING_BATCH_SIZE.getName(), Property.ELASTICSEARCH_INDEXING_BATCH_SIZE.getDefaultValue()));
@@ -161,6 +179,7 @@ public class ElasticSearchSchemaService extends AbstractSchemaService {
 				.build();
 
 		_createIndexIfNotExists();
+		_createScopeIndexIfNotExists();
 	}
 
 
@@ -175,7 +194,6 @@ public class ElasticSearchSchemaService extends AbstractSchemaService {
 		}
 	}
 
-
 	@Override
 	public Properties getServiceProperties() {
 		Properties serviceProps = new Properties();
@@ -186,9 +204,8 @@ public class ElasticSearchSchemaService extends AbstractSchemaService {
 		return serviceProps;
 	}
 
-
 	@Override
-	protected void implementationSpecificPut(List<Metric> metrics) {
+	protected void implementationSpecificPut(List<Metric> metrics, List<String> scopeNames) {
 		SystemAssert.requireArgument(metrics != null, "Metrics list cannot be null.");
 
 		_logger.info("{} new metrics need to be indexed on ES.", metrics.size());
@@ -198,11 +215,7 @@ public class ElasticSearchSchemaService extends AbstractSchemaService {
 
 		for(List<MetricSchemaRecord> records : fracturedList) {
 			if(!records.isEmpty()) {
-				if(_syncPut) {
-					_upsert(records);
-				} else {
-					_upsertAsync(records);
-				}
+				_upsert(records);
 			}
 		}
 
@@ -213,6 +226,25 @@ public class ElasticSearchSchemaService extends AbstractSchemaService {
 
 		_monitorService.modifyCounter(MonitorService.Counter.SCHEMARECORDS_WRITTEN, count, null);
 		_monitorService.modifyCounter(MonitorService.Counter.SCHEMARECORDS_WRITE_LATENCY, (System.currentTimeMillis() - start), null);
+
+		_logger.info("{} new scopes need to be indexed on ES.", scopeNames.size());
+
+		start = System.currentTimeMillis();
+		List<List<ScopeOnlySchemaRecord>> fracturedScopesList = _fractureScopes(scopeNames);
+
+		for(List<ScopeOnlySchemaRecord> records : fracturedScopesList) {
+			if(!records.isEmpty()) {
+				_upsertScopes(records);
+			}
+		}
+
+		count = 0;
+		for(List<ScopeOnlySchemaRecord> records : fracturedScopesList) {
+			count += records.size();
+		}
+
+		_monitorService.modifyCounter(MonitorService.Counter.SCOPENAMES_WRITTEN, count, null);
+		_monitorService.modifyCounter(MonitorService.Counter.SCOPENAMES_WRITE_LATENCY, (System.currentTimeMillis() - start), null);
 	}
 
 	/* Convert the given list of metrics to a list of metric schema records. At the same time, fracture the records list
@@ -241,6 +273,26 @@ public class ElasticSearchSchemaService extends AbstractSchemaService {
 					fracturedList.add(records);
 					records = new ArrayList<>(_bulkIndexingSize);
 				}
+			}
+		}
+
+		fracturedList.add(records);
+		return fracturedList;
+	}
+
+	/* Convert the given list of scopes to a list of scope only schema records. At the same time, fracture the records list
+	 * if its size is greater than INDEXING_BATCH_SIZE.
+	 */
+	protected List<List<ScopeOnlySchemaRecord>> _fractureScopes(List<String> scopeNames) {
+		List<List<ScopeOnlySchemaRecord>> fracturedList = new ArrayList<>();
+
+		List<ScopeOnlySchemaRecord> records = new ArrayList<>(_bulkIndexingSize);
+		for(String scope : scopeNames) {
+			records.add(new ScopeOnlySchemaRecord(scope));
+
+			if(records.size() == _bulkIndexingSize) {
+				fracturedList.add(records);
+				records = new ArrayList<>(_bulkIndexingSize);
 			}
 		}
 
@@ -523,7 +575,6 @@ public class ElasticSearchSchemaService extends AbstractSchemaService {
 		}
 	}
 
-
 	private List<String> _analyzedTokens(String query) {
 
 		if(!SchemaService.containsFilter(query)) {
@@ -552,9 +603,7 @@ public class ElasticSearchSchemaService extends AbstractSchemaService {
 		}
 	}
 
-
 	private void _upsert(List<MetricSchemaRecord> records) {
-
 		String requestUrl = new StringBuilder().append("/")
 				.append(INDEX_NAME)
 				.append("/")
@@ -570,6 +619,7 @@ public class ElasticSearchSchemaService extends AbstractSchemaService {
 			String requestBody = _mapper.writeValueAsString(msrList);
 			Response response = _esRestClient.performRequest(HttpMethod.POST.getName(), requestUrl, Collections.emptyMap(), new StringEntity(requestBody));
 			strResponse = extractResponse(response);
+
 		} catch (IOException e) {
 			//TODO: Retry with exponential back-off for handling EsRejectedExecutionException/RemoteTransportException/TimeoutException??
 			throw new SystemException(e);
@@ -598,77 +648,93 @@ public class ElasticSearchSchemaService extends AbstractSchemaService {
 			}
 			//add to bloom filter
 			_addToBloomFilter(records);
+
 		} catch(IOException e) {
 			throw new SystemException("Failed to parse reponse of put metrics. The response was: " + strResponse, e);
 		}
 	}
 
-	private void _upsertAsync(List<MetricSchemaRecord> records) {
-
+	private void _upsertScopes(List<ScopeOnlySchemaRecord> records) {
 		String requestUrl = new StringBuilder().append("/")
-				.append(INDEX_NAME)
+				.append(SCOPE_INDEX_NAME)
 				.append("/")
-				.append(TYPE_NAME)
+				.append(SCOPE_TYPE_NAME)				
 				.append("/")
 				.append("_bulk")
 				.toString();
 
-		MetricSchemaRecordList msrList = new MetricSchemaRecordList(records, _idgenHashAlgo);
-		StringEntity entity;
+		String strResponse = "";
+
+		ScopeOnlySchemaRecordList scopeOnlySchemaRecordList = new ScopeOnlySchemaRecordList(records, _idgenHashAlgo);
+
 		try {
-			String requestBody = _mapper.writeValueAsString(msrList);
-			entity = new StringEntity(requestBody);
-		} catch (JsonProcessingException | UnsupportedEncodingException e) {
-			throw new SystemException("Failed to parse metrics to schema records when indexing.", e);
+			String requestBody = _scopeOnlyMapper.writeValueAsString(scopeOnlySchemaRecordList);
+			Response response = _esRestClient.performRequest(HttpMethod.POST.getName(), requestUrl, Collections.emptyMap(), new StringEntity(requestBody));
+			strResponse = extractResponse(response);
+		} catch (IOException e) {
+			//TODO: Retry with exponential back-off for handling EsRejectedExecutionException/RemoteTransportException/TimeoutException??
+			throw new SystemException(e);
 		}
 
-		ResponseListener responseListener = new ResponseListener() {
+		try {
+			PutResponse putResponse = new ObjectMapper().readValue(strResponse, PutResponse.class);
+			//TODO: If response contains HTTP 429 Too Many Requests (EsRejectedExecutionException), then retry with exponential back-off.
+			if(putResponse.errors) {
+				List<ScopeOnlySchemaRecord> recordsToRemove = new ArrayList<>();
+				for(Item item : putResponse.items) {
+					if(item.create != null && item.create.status != HttpStatus.SC_CONFLICT && item.create.status != HttpStatus.SC_CREATED) {
+						_logger.warn("Failed to index metric. Reason: " + new ObjectMapper().writeValueAsString(item.create.error));
+						recordsToRemove.add(scopeOnlySchemaRecordList.getRecord(item.create._id));
+					}
 
-			@Override
-			public void onSuccess(Response response) {
-				String strResponse = extractResponse(response);
-				try {
-					PutResponse putResponse = new ObjectMapper().readValue(strResponse, PutResponse.class);
-					//TODO: If response contains HTTP 429 Too Many Requests (EsRejectedExecutionException), then retry with exponential back-off.
-					if(putResponse.errors) {
-						List<MetricSchemaRecord> recordsToRemove = new ArrayList<>();
-						for(Item item : putResponse.items) {
-							if(item.create != null && item.create.status != HttpStatus.SC_CONFLICT && item.create.status != HttpStatus.SC_CREATED) {
-								_logger.warn("Failed to index metric. Reason: " + new ObjectMapper().writeValueAsString(item.create.error));
-								recordsToRemove.add(msrList.getRecord(item.create._id));
-							}
-
-							if(item.index != null && item.index.status == HttpStatus.SC_NOT_FOUND) {
-								_logger.warn("Index does not exist. Error: " + new ObjectMapper().writeValueAsString(item.index.error));
-								recordsToRemove.add(msrList.getRecord(item.index._id));
-							}
-						}
-						if(recordsToRemove.size() != 0) {
-							_logger.info("{} records were not written to ES", recordsToRemove.size());
-							records.removeAll(recordsToRemove);
-						}
-					} 
-					//add to bloom filter
-					_addToBloomFilter(records);
-				} catch(IOException e) {
-					_logger.warn("Failed to parse reponse of put metrics. The response was: " + strResponse, e);
+					if(item.index != null && item.index.status == HttpStatus.SC_NOT_FOUND) {
+						_logger.warn("Scope Index does not exist. Error: " + new ObjectMapper().writeValueAsString(item.index.error));
+						recordsToRemove.add(scopeOnlySchemaRecordList.getRecord(item.index._id));
+					}
+				}
+				if(recordsToRemove.size() != 0) {
+					_logger.info("{} records were not written to ES", recordsToRemove.size());
+					records.removeAll(recordsToRemove);
 				}
 			}
+			//add to bloom filter
+			_addToBloomFilterScopeOnly(records);
 
-			@Override
-			public void onFailure(Exception e) {
-				//TODO: Retry with exponential back-off for handling EsRejectedExecutionException/RemoteTransportException/TimeoutException??
-				_logger.warn("Failed to execute the indexing request.", e);
+		} catch(IOException e) {
+			throw new SystemException("Failed to parse reponse of put metrics. The response was: " + strResponse, e);
+		}
+
+		try {
+			PutResponse putResponse = new ObjectMapper().readValue(strResponse, PutResponse.class);
+			//TODO: If response contains HTTP 429 Too Many Requests (EsRejectedExecutionException), then retry with exponential back-off.
+			if(putResponse.errors) {
+				for(Item item : putResponse.items) {
+					if(item.create != null && item.create.status != HttpStatus.SC_CONFLICT && item.create.status != HttpStatus.SC_CREATED) {
+						_logger.warn("Failed to index scope. Reason: " + new ObjectMapper().writeValueAsString(item.create.error));
+					}
+
+					if(item.index != null && item.index.status == HttpStatus.SC_NOT_FOUND) {
+						_logger.warn("Index does not exist. Error: " + new ObjectMapper().writeValueAsString(item.index.error));
+					}
+				}
 			}
-		};
-
-		_esRestClient.performRequestAsync(HttpMethod.POST.getName(), requestUrl, Collections.emptyMap(), entity, responseListener);
+		} catch(IOException e) {
+			throw new SystemException("Failed to parse reponse of put metrics. The response was: " + strResponse, e);
+		}
 	}
 
 	protected void _addToBloomFilter(List<MetricSchemaRecord> records){
 		_logger.info("Adding {} records into bloom filter.", records.size());
 		for(MetricSchemaRecord record : records) {		
 			String key = constructKey(record.getScope(), record.getMetric(), record.getTagKey(), record.getTagValue(), record.getNamespace());		
+			bloomFilter.put(key);		
+		}		
+	}
+
+	protected void _addToBloomFilterScopeOnly(List<ScopeOnlySchemaRecord> records){
+		_logger.info("Adding {} records into scope only bloom filter.", records.size());
+		for(ScopeOnlySchemaRecord record : records) {		
+			String key = constructScopeOnlyKey(record.getScope());		
 			bloomFilter.put(key);		
 		}		
 	}
@@ -823,7 +889,6 @@ public class ElasticSearchSchemaService extends AbstractSchemaService {
 		return queryNode;
 	}
 
-
 	private ObjectNode _constructAggsNode(RecordType type, long limit, ObjectMapper mapper) {
 
 		ObjectNode termsNode = mapper.createObjectNode();
@@ -910,8 +975,20 @@ public class ElasticSearchSchemaService extends AbstractSchemaService {
 		return mapper;
 	}
 
+	private ObjectMapper _createScopeOnlyObjectMapper() {
+		ObjectMapper mapper = new ObjectMapper();
 
-	private ObjectNode _createSettingsNode() {
+		mapper.setSerializationInclusion(Include.NON_NULL);
+		SimpleModule module = new SimpleModule();
+		module.addSerializer(ScopeOnlySchemaRecordList.class, new ScopeOnlySchemaRecordList.Serializer());
+		module.addDeserializer(ScopeOnlySchemaRecordList.class, new ScopeOnlySchemaRecordList.Deserializer());
+		module.addDeserializer(List.class, new ScopeOnlySchemaRecordList.AggDeserializer());
+		mapper.registerModule(module);
+
+		return mapper;
+	}
+
+	private ObjectNode _createSettingsNode(int replicationFactor, int numShards) {
 		ObjectMapper mapper = new ObjectMapper();
 
 		ObjectNode metadataAnalyzer = mapper.createObjectNode();
@@ -930,17 +1007,15 @@ public class ElasticSearchSchemaService extends AbstractSchemaService {
 
 		ObjectNode indexNode = mapper.createObjectNode();
 		indexNode.put("max_result_window", INDEX_MAX_RESULT_WINDOW);
-		indexNode.put("number_of_replicas", _replicationFactor);
-		indexNode.put("number_of_shards", _numShards);
+		indexNode.put("number_of_replicas", replicationFactor);
+		indexNode.put("number_of_shards", numShards);
 
 		ObjectNode settingsNode = mapper.createObjectNode();
 		settingsNode.put("analysis", analysisNode);
 		settingsNode.put("index", indexNode);
 
 		return settingsNode;
-
 	}
-
 
 	private ObjectNode _createMappingsNode() {
 		ObjectMapper mapper = new ObjectMapper();
@@ -952,17 +1027,32 @@ public class ElasticSearchSchemaService extends AbstractSchemaService {
 		propertiesNode.put(RecordType.TAGV.getName(), _createFieldNode(FIELD_TYPE_TEXT));
 		propertiesNode.put(RecordType.NAMESPACE.getName(), _createFieldNode(FIELD_TYPE_TEXT));
 
-		propertiesNode.put("mts", _createFieldNode(FIELD_TYPE_DATE));
+		propertiesNode.put("mts", _createFieldNodeNoAnalyzer(FIELD_TYPE_DATE));
 
 		ObjectNode typeNode = mapper.createObjectNode();
 		typeNode.put("properties", propertiesNode);
 
 		ObjectNode mappingsNode = mapper.createObjectNode();
 		mappingsNode.put(TYPE_NAME, typeNode);
-
 		return mappingsNode;
 	}
 
+	private ObjectNode _createScopeMappingsNode() {
+		ObjectMapper mapper = new ObjectMapper();
+
+		ObjectNode propertiesNode = mapper.createObjectNode();
+		propertiesNode.put(RecordType.SCOPE.getName(), _createFieldNode(FIELD_TYPE_TEXT));
+
+		propertiesNode.put("mts", _createFieldNodeNoAnalyzer(FIELD_TYPE_DATE));
+
+		ObjectNode typeNode = mapper.createObjectNode();
+		typeNode.put("properties", propertiesNode);
+
+		ObjectNode mappingsNode = mapper.createObjectNode();
+		mappingsNode.put(SCOPE_TYPE_NAME, typeNode);
+
+		return mappingsNode;
+	}
 
 	private ObjectNode _createFieldNode(String type) {
 		ObjectMapper mapper = new ObjectMapper();
@@ -978,6 +1068,14 @@ public class ElasticSearchSchemaService extends AbstractSchemaService {
 		return fieldNode;
 	}
 
+	private ObjectNode _createFieldNodeNoAnalyzer(String type) {
+		ObjectMapper mapper = new ObjectMapper();
+
+		ObjectNode fieldNode = mapper.createObjectNode();
+		fieldNode.put("type", type);
+		return fieldNode;
+	}
+
 	private void _createIndexIfNotExists() {
 		try {
 			Response response = _esRestClient.performRequest(HttpMethod.HEAD.getName(), "/" + INDEX_NAME);
@@ -988,7 +1086,7 @@ public class ElasticSearchSchemaService extends AbstractSchemaService {
 				ObjectMapper mapper = new ObjectMapper();
 
 				ObjectNode rootNode = mapper.createObjectNode();
-				rootNode.put("settings", _createSettingsNode());
+				rootNode.put("settings", _createSettingsNode(_replicationFactor, _numShards));
 				rootNode.put("mappings", _createMappingsNode());
 
 				String settingsAndMappingsJson = rootNode.toString();
@@ -999,6 +1097,30 @@ public class ElasticSearchSchemaService extends AbstractSchemaService {
 			}
 		} catch (Exception e) {
 			_logger.error("Failed to check/create elasticsearch index. ElasticSearchSchemaService may not function.", e);
+		}
+	}
+
+	private void _createScopeIndexIfNotExists() {
+		try {
+			Response response = _esRestClient.performRequest(HttpMethod.HEAD.getName(), "/" + SCOPE_INDEX_NAME);
+			boolean indexExists = response.getStatusLine().getStatusCode() == HttpStatus.SC_OK ? true : false;
+
+			if(!indexExists) {
+				_logger.info("Index [" + SCOPE_INDEX_NAME + "] does not exist. Will create one.");
+				ObjectMapper mapper = new ObjectMapper();
+
+				ObjectNode rootNode = mapper.createObjectNode();
+				rootNode.put("settings", _createSettingsNode(_replicationFactorForScopeIndex, _numShardsForScopeIndex));
+				rootNode.put("mappings", _createScopeMappingsNode());
+
+				String settingsAndMappingsJson = rootNode.toString();
+				String requestUrl = new StringBuilder().append("/").append(SCOPE_INDEX_NAME).toString();
+
+				response = _esRestClient.performRequest(HttpMethod.PUT.getName(), requestUrl, Collections.emptyMap(), new StringEntity(settingsAndMappingsJson));
+				extractResponse(response);
+			}
+		} catch (Exception e) {
+			_logger.error("Failed to check/create elasticsearch scope index. ElasticSearchSchemaService may not function.", e);
 		}
 	}
 
@@ -1050,12 +1172,20 @@ public class ElasticSearchSchemaService extends AbstractSchemaService {
 		ELASTICSEARCH_NUM_REPLICAS("service.property.schema.elasticsearch.num.replicas", "1"),
 		/** Shard count for metadata_index. */
 		ELASTICSEARCH_SHARDS_COUNT("service.property.schema.elasticsearch.shards.count", "10"),
+		/** Replication factor for scopenames */
+		ELASTICSEARCH_NUM_REPLICAS_FOR_SCOPE_INDEX("service.property.schema.elasticsearch.num.replicas.for.scope.index", "1"),
+		/** Shard count for scopenames */
+		ELASTICSEARCH_SHARDS_COUNT_FOR_SCOPE_INDEX("service.property.schema.elasticsearch.shards.count.for.scope.index", "10"),
 		/** The no. of records to batch for bulk indexing requests.
 		 * https://www.elastic.co/guide/en/elasticsearch/guide/current/indexing-performance.html#_using_and_sizing_bulk_requests 
 		 */
 		ELASTICSEARCH_INDEXING_BATCH_SIZE("service.property.schema.elasticsearch.indexing.batch.size", "10000"),
 		/** The hashing algorithm to use for generating document id. */
-		ELASTICSEARCH_IDGEN_HASH_ALGO("service.property.schema.elasticsearch.idgen.hash.algo", "MD5");
+		ELASTICSEARCH_IDGEN_HASH_ALGO("service.property.schema.elasticsearch.idgen.hash.algo", "MD5"),
+		/** Name of scope only index */
+		ELASTICSEARCH_SCOPE_INDEX_NAME("service.property.schema.elasticsearch.scope.index.name", "scopenames"),
+		/** Type within scope only index */
+		ELASTICSEARCH_SCOPE_TYPE_NAME("service.property.schema.elasticsearch.scope.type.name", "scope_type");
 
 		private final String _name;
 		private final String _defaultValue;
@@ -1083,7 +1213,6 @@ public class ElasticSearchSchemaService extends AbstractSchemaService {
 			return _defaultValue;
 		}
 	}
-
 
 	static class PutResponse {
 		private int took;

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/schema/ScopeOnlySchemaRecordList.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/schema/ScopeOnlySchemaRecordList.java
@@ -1,0 +1,154 @@
+package com.salesforce.dva.argus.service.schema;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.codec.digest.DigestUtils;
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import com.salesforce.dva.argus.entity.ScopeOnlySchemaRecord;
+import com.salesforce.dva.argus.service.SchemaService.RecordType;
+import com.salesforce.dva.argus.service.schema.MetricSchemaRecordList.HashAlgorithm;
+
+import net.openhft.hashing.LongHashFunction;
+
+/**
+ * Represents a list of scope names from discovery queries.
+ * Internally it has a mapping from hash id of scope names to the actual scope names.
+ *
+ * @author  Dilip Devaraj (ddevaraj@salesforce.com)
+ */
+public class ScopeOnlySchemaRecordList {
+	
+	private Map<String, ScopeOnlySchemaRecord> _idToSchemaRecordMap = new HashMap<>();
+	private String _scrollID;
+
+	public ScopeOnlySchemaRecordList(List<ScopeOnlySchemaRecord> records, String scrollID) {
+		int count = 0;
+		for(ScopeOnlySchemaRecord record : records) {
+			_idToSchemaRecordMap.put(String.valueOf(count++), record);
+		}
+		setScrollID(scrollID);
+	}
+	
+	public ScopeOnlySchemaRecordList(List<ScopeOnlySchemaRecord> records, HashAlgorithm algorithm) {
+		for(ScopeOnlySchemaRecord record : records) {
+			String id = null;
+			String scopeOnly = ScopeOnlySchemaRecord.print(record);
+			if(HashAlgorithm.MD5.equals(algorithm)) {
+				id = DigestUtils.md5Hex(scopeOnly);
+			} else {
+				id = String.valueOf(LongHashFunction.xx().hashChars(scopeOnly));
+			}
+			_idToSchemaRecordMap.put(id, new ScopeOnlySchemaRecord(scopeOnly));
+		}
+	}
+	
+	public List<ScopeOnlySchemaRecord> getRecords() {
+		return new ArrayList<>(_idToSchemaRecordMap.values());
+	}
+	
+	public String getScrollID() {
+		return _scrollID;
+	}
+
+	public void setScrollID(String scrollID) {
+		this._scrollID = scrollID;
+	}
+	
+	ScopeOnlySchemaRecord getRecord(String id) {
+		return _idToSchemaRecordMap.get(id);
+	}
+	
+	static class Serializer extends JsonSerializer<ScopeOnlySchemaRecordList> {
+
+		@Override
+		public void serialize(ScopeOnlySchemaRecordList list, JsonGenerator jgen, SerializerProvider provider)
+				throws IOException, JsonProcessingException {
+			
+			ObjectMapper mapper = new ObjectMapper();
+			mapper.setSerializationInclusion(Include.NON_NULL);
+			
+			for(Map.Entry<String, ScopeOnlySchemaRecord> entry : list._idToSchemaRecordMap.entrySet()) {
+				jgen.writeRaw("{ \"index\" : {\"_id\" : \"" + entry.getKey() + "\"}}");
+				jgen.writeRaw(System.lineSeparator());
+				String fieldsData = mapper.writeValueAsString(entry.getValue());
+				String timeStampField = "\"mts\":" + System.currentTimeMillis();
+				jgen.writeRaw(fieldsData.substring(0, fieldsData.length()-1) + "," + timeStampField + "}");
+				jgen.writeRaw(System.lineSeparator());
+			}
+		}
+    }
+	
+	static class Deserializer extends JsonDeserializer<ScopeOnlySchemaRecordList> {
+
+		@Override
+		public ScopeOnlySchemaRecordList deserialize(JsonParser jp, DeserializationContext context)
+				throws IOException, JsonProcessingException {
+			
+			String scrollID = null;
+			List<ScopeOnlySchemaRecord> records = Collections.emptyList();
+			
+			JsonNode rootNode = jp.getCodec().readTree(jp);
+			if(rootNode.has("_scroll_id")) {
+				scrollID = rootNode.get("_scroll_id").asText();
+			}
+			JsonNode hits = rootNode.get("hits").get("hits");
+			
+			if(JsonNodeType.ARRAY.equals(hits.getNodeType())) {
+				records = new ArrayList<>(hits.size());
+				Iterator<JsonNode> iter = hits.elements();
+				while(iter.hasNext()) {
+					JsonNode hit = iter.next();
+					JsonNode source = hit.get("_source");
+					
+					JsonNode scopeNode = source.get(RecordType.SCOPE.getName());
+					
+					records.add(new ScopeOnlySchemaRecord(scopeNode.asText()));
+				}
+			}
+			
+			return new ScopeOnlySchemaRecordList(records, scrollID);
+		}
+	}
+	
+	static class AggDeserializer extends JsonDeserializer<List<String>> {
+
+		@Override
+		public List<String> deserialize(JsonParser jp, DeserializationContext context)
+				throws IOException, JsonProcessingException {
+			
+			List<String> values = Collections.emptyList();
+			
+			JsonNode rootNode = jp.getCodec().readTree(jp);
+			JsonNode buckets = rootNode.get("aggregations").get("distinct_values").get("buckets");
+			
+			if(JsonNodeType.ARRAY.equals(buckets.getNodeType())) {
+				values = new ArrayList<>(buckets.size());
+				Iterator<JsonNode> iter = buckets.elements();
+				while(iter.hasNext()) {
+					JsonNode bucket = iter.next();
+					String value  = bucket.get("key").asText();
+					values.add(value);
+				}
+			}
+			
+			return values;
+		}
+	}
+}

--- a/ArgusCore/src/test/java/com/salesforce/dva/argus/service/schema/AbstractSchemaServiceTest.java
+++ b/ArgusCore/src/test/java/com/salesforce/dva/argus/service/schema/AbstractSchemaServiceTest.java
@@ -97,7 +97,7 @@ public class AbstractSchemaServiceTest extends AbstractTest {
 				 count.addAndGet(metrics.size());
 				 return null;
 			}
-		}).when(spyService).implementationSpecificPut(Mockito.anyListOf(Metric.class));
+		}).when(spyService).implementationSpecificPut(Mockito.anyListOf(Metric.class),Mockito.anyListOf(String.class));
 		return spyService;
 	}
 	


### PR DESCRIPTION
Have separate bloom filter for scope names only
Remove async put from ElasticSchema Service. ES writes will be synchronous only
Make number of shards, replication factor, scope index name, scope type name configurable
