### PR TITLE
Update dashboard markup editor and add attribute to ag-metric

### DIFF
--- a/ArgusWeb/app/css/main.css
+++ b/ArgusWeb/app/css/main.css
@@ -476,3 +476,11 @@ a.definition-tip, a.definition-tip:hover, a.definition-tip:visited {
 .tooltip > .tooltip-inner {background-color: steelblue; text-align: left}
 .tooltip.bottom > .tooltip-arrow {border-bottom-color: steelblue;}
 .tooltip.in {opacity: 1}
+
+/* dashboard markup editor fullscreen  */
+.CodeMirror-fullscreen {
+  position: fixed;
+  top: 55px; left: 0; right: 0; bottom: 0;
+  height: auto;
+  z-index: ;
+}

--- a/ArgusWeb/app/index.html
+++ b/ArgusWeb/app/index.html
@@ -65,8 +65,23 @@
 <!-- old bower utilities -->
 <script src="node_modules/codemirror/lib/codemirror.js"></script>
 <script src="node_modules/codemirror/mode/xml/xml.js"></script>
+<script src="node_modules/codemirror/mode/javascript/javascript.js"></script>
+<script src="node_modules/codemirror/mode/css/css.js"></script>
 <script src="node_modules/codemirror/mode/properties/properties.js"></script>
 <script src="node_modules/codemirror/mode/htmlmixed/htmlmixed.js"></script>
+<script src="node_modules/codemirror/addon/hint/show-hint.js"></script>
+<link href="node_modules/codemirror/addon/hint/show-hint.css" rel="stylesheet" />
+<script src="node_modules/codemirror/addon/hint/xml-hint.js"></script>
+<script src="node_modules/codemirror/addon/hint/html-hint.js"></script>
+<script src="node_modules/codemirror/addon/hint/css-hint.js"></script>
+<link href="node_modules/codemirror/addon/fold/foldgutter.css" rel="stylesheet">
+<script src="node_modules/codemirror/addon/fold/foldcode.js"></script>
+<script src="node_modules/codemirror/addon/fold/foldgutter.js"></script>
+<script src="node_modules/codemirror/addon/fold/comment-fold.js"></script>
+<script src="node_modules/codemirror/addon/fold/xml-fold.js"></script>
+<script src="node_modules/codemirror/addon/edit/matchtags.js"></script>
+<script src="node_modules/codemirror/addon/edit/closetag.js"></script>
+<script src="node_modules/codemirror/addon/display/fullscreen.js"></script>
 <script src="node_modules/angular-ui-codemirror/src/ui-codemirror.js"></script>
 <script src="node_modules/ngstorage/ngStorage.js"></script>
 <script src="node_modules/angular-table/dist/angular-table.js"></script>

--- a/ArgusWeb/app/js/controllers/dashboardsDetail.js
+++ b/ArgusWeb/app/js/controllers/dashboardsDetail.js
@@ -29,7 +29,7 @@ angular.module('argus.controllers.dashboards.detail', ['ngResource', 'ui.codemir
 		};
 
 		$scope.editorLoaded = function (editor) {
-			editor.setSize(null, '30em');
+			editor.setSize(null, 'auto');
 		};
 
 		$scope.isTabSelected = function (tab) {
@@ -88,7 +88,21 @@ angular.module('argus.controllers.dashboards.detail', ['ngResource', 'ui.codemir
 			lineWrapping: true,
 			lineNumbers: true,
 			mode: 'htmlmixed',
-			viewportMargin: 500
+			viewportMargin: Infinity,
+			tabSize: 2,
+			foldGutter: true,
+			gutters: ['CodeMirror-linenumbers', 'CodeMirror-foldgutter'],
+			autoCloseTags: true,
+			matchTags: {bothTags: true},
+			extraKeys: { /* key board short cuts in the the editor */
+				'Alt-Space': 'autocomplete',
+				'Ctrl-Alt-F': function(editor) {
+					editor.setOption('fullScreen', !editor.getOption('fullScreen'));
+				},
+				'Esc': function(editor) {
+					if (editor.getOption('fullScreen')) editor.setOption('fullScreen', false);
+				}
+			}
 		};
 
 		if ($scope.dashboardId > 0) {

--- a/ArgusWeb/app/js/controllers/viewElements.js
+++ b/ArgusWeb/app/js/controllers/viewElements.js
@@ -12,6 +12,7 @@ angular.module('argus.controllers.viewelements', [])
 			'name': seriesData.name,
 			'color': seriesData.color,
 			'extraYAxis': seriesData.extraYAxis,
+			'hideTags': seriesData.hideTags,
 			'expression': expression,
 			'metricSpecificOptions': metricSpecificOptions
 		};

--- a/ArgusWeb/app/js/controllers/viewElements.js
+++ b/ArgusWeb/app/js/controllers/viewElements.js
@@ -13,6 +13,8 @@ angular.module('argus.controllers.viewelements', [])
 			'color': seriesData.color,
 			'extraYAxis': seriesData.extraYAxis,
 			'hideTags': seriesData.hideTags,
+			'hideScope': seriesData.hideScope,
+			'hideMetric': seriesData.hideMetric,
 			'expression': expression,
 			'metricSpecificOptions': metricSpecificOptions
 		};

--- a/ArgusWeb/app/js/directives/charts/metric.js
+++ b/ArgusWeb/app/js/directives/charts/metric.js
@@ -27,6 +27,8 @@ angular.module('argus.directives.charts.metric', [])
 			seriesData.name = attributes.seriesname;
 			seriesData.extraYAxis = attributes.extraYaxis;
 			seriesData.hideTags = attributes.hidetags;
+			seriesData.hideScope = attributes.hidescope;
+			seriesData.hideMetric = attributes.hidemetric;
 
 			if (attributes.value && attributes.value.length > 0) {
 				value = attributes.value;

--- a/ArgusWeb/app/js/directives/charts/metric.js
+++ b/ArgusWeb/app/js/directives/charts/metric.js
@@ -26,6 +26,7 @@ angular.module('argus.directives.charts.metric', [])
 			seriesData.color = attributes.seriescolor;
 			seriesData.name = attributes.seriesname;
 			seriesData.extraYAxis = attributes.extraYaxis;
+			seriesData.hideTags = attributes.hidetags;
 
 			if (attributes.value && attributes.value.length > 0) {
 				value = attributes.value;

--- a/ArgusWeb/app/js/services/charts/dataProcessing.js
+++ b/ArgusWeb/app/js/services/charts/dataProcessing.js
@@ -26,9 +26,9 @@ angular.module('argus.services.charts.dataProcessing', [])
 
 	function createMetricWithScopeMetricAndTags(metric){
 		return {
-			scopeMetric: metric.scope + ":" + metric.metric,
+			scopeMetric: metric.scope + ':' + metric.metric,
 			tags: createTagString(metric.tags)
-		}
+		};
 	}
 
 	function createSeriesName(metric) {
@@ -36,10 +36,11 @@ angular.module('argus.services.charts.dataProcessing', [])
 			return metric.displayName;
 		}
 
-		var scope = metric.scope;
-		var name = metric.metric;
+		var scope = metric.scope ? metric.scope: '';
+		var name = metric.metric ? metric.metric : '';
 		var tags = createTagString(metric.tags);
-		return scope + ':' + name + tags;
+		if (scope !== '' && name !== '') scope = scope + ':';
+		return scope + name + tags;
 	}
 
 	function createTagString(tags) {
@@ -228,6 +229,8 @@ angular.module('argus.services.charts.dataProcessing', [])
 						processedMetric['color'] = metrics.color;
 						processedMetric['extraYAxis'] = metrics.extraYAxis;
 						processedMetric['hideTags'] = metrics.hideTags;
+						processedMetric['hideScope'] = metrics.hideScope;
+						processedMetric['hideMetric'] = metrics.hideMetric;
 						processedMetric['metricSpecificOptions'] = this.getMetricSpecificOptionsInArray(metricSpecificOptions);
 
 						// update metric list with new processed metric object
@@ -273,32 +276,28 @@ angular.module('argus.services.charts.dataProcessing', [])
 					if (metricItem.hideTags !== undefined) {
 						if (metricItem.hideTags === 'true') {
 							// delete all tags
-							data = data.map(function(item) {
-								delete item.tags;
-								return item;
-							});
+							delete data[i].tags;
 						} else {
 							// delete provided tags
 							var droppedTags = metricItem.hideTags.split(',').map(function(tag) {
 								return tag.trim();
 							});
-							data = data.map(function(item) {
-								droppedTags.forEach(function(tag){
-									delete item.tags[tag];
-								});
-								return item;
+							droppedTags.forEach(function(tag) {
+								delete data[i].tags[tag];
 							});
 						}
 					}
+
+					if (metricItem.hideScope) delete data[i].scope;
+					if (metricItem.hideMetric) delete data[i].metric;
+
 					var metricName = (metricItem.name) ? metricItem.name : createSeriesName(data[i]);
 					var metricColor = (metricItem.color) ? metricItem.color : null;
 					var metricExtraYAxis = (metricItem.extraYAxis) ? metricItem.extraYAxis : null;
-					var metricshideTags = true;
 					var objSeries = {
 						name: metricName,
 						color: metricColor,
 						extraYAxis: metricExtraYAxis,
-						hideTags: metricshideTags,
 						data: series
 					};
 					var objSeriesWithOptions = ChartOptionService.setCustomOptions(objSeries, metricItem.metricSpecificOptions);

--- a/ArgusWeb/app/js/services/charts/dataProcessing.js
+++ b/ArgusWeb/app/js/services/charts/dataProcessing.js
@@ -227,6 +227,7 @@ angular.module('argus.services.charts.dataProcessing', [])
 						processedMetric['name'] = metrics.name;
 						processedMetric['color'] = metrics.color;
 						processedMetric['extraYAxis'] = metrics.extraYAxis;
+						processedMetric['hideTags'] = metrics.hideTags;
 						processedMetric['metricSpecificOptions'] = this.getMetricSpecificOptionsInArray(metricSpecificOptions);
 
 						// update metric list with new processed metric object
@@ -269,13 +270,35 @@ angular.module('argus.services.charts.dataProcessing', [])
 							series.push([timestamp, value]);
 						}
 					}
+					if (metricItem.hideTags !== undefined) {
+						if (metricItem.hideTags === 'true') {
+							// delete all tags
+							data = data.map(function(item) {
+								delete item.tags;
+								return item;
+							});
+						} else {
+							// delete provided tags
+							var droppedTags = metricItem.hideTags.split(',').map(function(tag) {
+								return tag.trim();
+							});
+							data = data.map(function(item) {
+								droppedTags.forEach(function(tag){
+									delete item.tags[tag];
+								});
+								return item;
+							});
+						}
+					}
 					var metricName = (metricItem.name) ? metricItem.name : createSeriesName(data[i]);
 					var metricColor = (metricItem.color) ? metricItem.color : null;
 					var metricExtraYAxis = (metricItem.extraYAxis) ? metricItem.extraYAxis : null;
+					var metricshideTags = true;
 					var objSeries = {
 						name: metricName,
 						color: metricColor,
 						extraYAxis: metricExtraYAxis,
+						hideTags: metricshideTags,
 						data: series
 					};
 					var objSeriesWithOptions = ChartOptionService.setCustomOptions(objSeries, metricItem.metricSpecificOptions);

--- a/ArgusWeb/app/package-lock.json
+++ b/ArgusWeb/app/package-lock.json
@@ -375,9 +375,9 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "codemirror": {
-      "version": "5.28.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.28.0.tgz",
-      "integrity": "sha512-E/Z6050shti9v9ivl0dUClVRM4xaH204jsJmEpNYC6KDTlQwAz+5DdhLzn0tjaL/Mp1P0J1uhZokcSP2RFSwlA=="
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.39.0.tgz",
+      "integrity": "sha512-vpJRray/0ZCt9FiS7UcVr1JAm6OBdUt6TA/94Q7MScr8TnutVdQWh/WPr0migzaBPQmYvY7I9UZNvbsaLESIuQ=="
     },
     "combined-stream": {
       "version": "1.0.5",

--- a/ArgusWeb/app/package.json
+++ b/ArgusWeb/app/package.json
@@ -21,7 +21,7 @@
 		"angular-utils-pagination": "~0.11.1",
 		"angulartics": "~0.17.2",
 		"bootstrap": "~3.3.7",
-		"codemirror": "~5.28.0",
+		"codemirror": "~5.39.0",
 		"d3": "^4.2.1",
 		"d3fc-rebind": "^4.1.1",
 		"d3fc-sample": "^3.0.4",

--- a/ArgusWeb/webpack_index.html
+++ b/ArgusWeb/webpack_index.html
@@ -39,8 +39,23 @@
 <!-- old bower utilities -->
 <script src="node_modules/codemirror/lib/codemirror.js"></script>
 <script src="node_modules/codemirror/mode/xml/xml.js"></script>
+<script src="node_modules/codemirror/mode/javascript/javascript.js"></script>
+<script src="node_modules/codemirror/mode/css/css.js"></script>
 <script src="node_modules/codemirror/mode/properties/properties.js"></script>
 <script src="node_modules/codemirror/mode/htmlmixed/htmlmixed.js"></script>
+<script src="node_modules/codemirror/addon/hint/show-hint.js"></script>
+<link href="node_modules/codemirror/addon/hint/show-hint.css" rel="stylesheet" />
+<script src="node_modules/codemirror/addon/hint/xml-hint.js"></script>
+<script src="node_modules/codemirror/addon/hint/html-hint.js"></script>
+<script src="node_modules/codemirror/addon/hint/css-hint.js"></script>
+<link href="node_modules/codemirror/addon/fold/foldgutter.css" rel="stylesheet">
+<script src="node_modules/codemirror/addon/fold/foldcode.js"></script>
+<script src="node_modules/codemirror/addon/fold/foldgutter.js"></script>
+<script src="node_modules/codemirror/addon/fold/comment-fold.js"></script>
+<script src="node_modules/codemirror/addon/fold/xml-fold.js"></script>
+<script src="node_modules/codemirror/addon/edit/matchtags.js"></script>
+<script src="node_modules/codemirror/addon/edit/closetag.js"></script>
+<script src="node_modules/codemirror/addon/display/fullscreen.js"></script>
 <script src="node_modules/angular-ui-codemirror/src/ui-codemirror.js"></script>
 <script src="node_modules/ngstorage/ngStorage.js"></script>
 <script src="node_modules/angular-table/dist/angular-table.js"></script>


### PR DESCRIPTION
**Changes to the markup editor**
1. Add code folding.
2. Highlight matching tags.
3. Extend the editor height to show the entire markup.
<img width="1328" alt="newmarkupwindow" src="https://user-images.githubusercontent.com/6592110/42845620-64669fa6-89cb-11e8-84a5-a54a4b4c00ab.png">

4. Fullscreen mode. To enter fullscreen, press: `Ctrl-Alt-F`. To exit fullscreen press: `Esc`.
<img width="1440" alt="fullscreen" src="https://user-images.githubusercontent.com/6592110/42845677-952abd20-89cb-11e8-9d89-ad1dc58d7360.png">

5. Autocomplete with some HTML, CSS, and Javascript code. To trigger autocomplete, press `Alt-Space`.
6. Autocomplete matching tags.
![autocomplete](https://user-images.githubusercontent.com/6592110/42845735-b954f79c-89cb-11e8-9a72-468ebec01972.gif)
7. Syntax highlighting for CSS and Javascript code as well.

**Changes to ag-metric**
1. `hideTags` attribute to hide tags. Set it to true to hide all tags in the tooltip and legend of that chart. Set it to comma separated values to hide a few tags. 
<img width="493" alt="hide all tags" src="https://user-images.githubusercontent.com/6592110/42845865-1e832a76-89cc-11e8-9ae8-a7ae35b7d70f.png">
<img width="570" alt="hide multiple tags" src="https://user-images.githubusercontent.com/6592110/42845964-609e7b7c-89cc-11e8-87db-c470d94e5647.png">

2. `hideScope` and `hideMetric` attribute to hide scope values and metric values correspondingly in tooltip and legend.
<img width="387" alt="hide scope and metric" src="https://user-images.githubusercontent.com/6592110/42846038-96c87cde-89cc-11e8-9f1e-f09b791b5cf7.png">
