### PR TITLE
javadoc plugin 3.0.0 -> use new doclint config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -360,7 +360,7 @@
                                     <goal>jar</goal>
                                 </goals>
                                 <configuration>
-                                    <additionalparam>-Xdoclint:none</additionalparam>
+                                    <doclint>none</doclint>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
In maven-javadoc-plugin 3.0.0 they removed additionalparam and made a
proper doclint configuration property

See: https://issues.apache.org/jira/browse/MJAVADOC-474