### PR TITLE
Unbind docker-maven: no automatic build/push

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,22 +152,6 @@
                             <imageTag>${project.version}</imageTag>
                         </imageTags>
                     </configuration>
-                    <executions>
-                        <execution>
-                            <id>build-image</id>
-                            <phase>package</phase>
-                            <goals>
-                                <goal>build</goal>
-                            </goals>
-                        </execution>
-                        <execution>
-                            <id>push-image</id>
-                            <phase>deploy</phase>
-                            <goals>
-                                <goal>push</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
This will make it so you have to explicitly tell the docker-maven-plugin to activate (see [the doc](https://github.com/spotify/docker-maven-plugin/tree/v0.4.11#bind-docker-commands-to-maven-phases))