### PR TITLE
Use actual verion instead of project.version since maven is not refle…

### DIFF
--- a/ArgusClient/pom.xml
+++ b/ArgusClient/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>argus</artifactId>
         <groupId>com.salesforce.argus</groupId>
-        <version>${project.version}</version>
+        <version>2.17.0</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>argus-client</artifactId>

--- a/ArgusCore/pom.xml
+++ b/ArgusCore/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>argus</artifactId>
         <groupId>com.salesforce.argus</groupId>
-        <version>${project.version}</version>
+        <version>2.17.0</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>argus-core</artifactId>

--- a/ArgusSDK/pom.xml
+++ b/ArgusSDK/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>argus</artifactId>
         <groupId>com.salesforce.argus</groupId>
-        <version>${project.version}</version>
+        <version>2.17.0</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>argus-sdk</artifactId>

--- a/ArgusWeb/pom.xml
+++ b/ArgusWeb/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>argus</artifactId>
         <groupId>com.salesforce.argus</groupId>
-        <version>${project.version}</version>
+        <version>2.17.0</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>argus-web</artifactId>

--- a/ArgusWebServices/pom.xml
+++ b/ArgusWebServices/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>argus</artifactId>
         <groupId>com.salesforce.argus</groupId>
-        <version>${project.version}</version>
+        <version>2.17.0</version>
         <relativePath>..</relativePath>
     </parent>
     <artifactId>argus-webservices</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.salesforce.argus</groupId>
     <artifactId>argus</artifactId>
-    <version>${project.version}</version>
+    <version>2.17.0</version>
     <packaging>pom</packaging>
 
     <name>Argus</name>


### PR DESCRIPTION
…cting this within pom's version

The contents within pom.xml is not replaced with exact version, hence users cannot reference it from their maven project.

See https://stackoverflow.com/questions/10582054/maven-project-version-inheritance-do-i-have-to-specify-the-parent-version

