### PR TITLE
Part 2: paginated APIs to search alerts filter on alertname or owner name

### DIFF
--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/entity/Alert.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/entity/Alert.java
@@ -161,7 +161,8 @@ import com.salesforce.dva.argus.service.metric.MetricReader;
 					),
 			@NamedQuery(
 					name = "Alert.countByOwnerWithSearchText",
-					query = "SELECT count(a) FROM Alert a WHERE a.owner = :owner AND a.id in (SELECT jpa.id from JPAEntity jpa where jpa.deleted = false) AND (a.name LIKE :searchtext OR a.owner.userName LIKE :searchtext)"
+					query = "SELECT count(a) FROM Alert a WHERE a.owner = :owner AND a.id in (SELECT jpa.id from JPAEntity jpa where jpa.deleted = false) "
+							+ "AND (a.name LIKE :searchtext OR a.owner.userName LIKE :searchtext)"
 					),
 			@NamedQuery(
 					name = "Alert.countSharedAlerts",
@@ -169,7 +170,8 @@ import com.salesforce.dva.argus.service.metric.MetricReader;
 					),
 			@NamedQuery(
 					name = "Alert.countSharedAlertsWithSearchText",
-					query = "SELECT count(a) FROM Alert a WHERE a.shared = true AND a.id IN (SELECT jpa.id FROM JPAEntity jpa WHERE jpa.deleted = false) AND (a.name LIKE :searchtext OR a.owner.userName LIKE :searchtext)"
+					query = "SELECT count(a) FROM Alert a WHERE a.shared = true AND a.id IN (SELECT jpa.id FROM JPAEntity jpa WHERE jpa.deleted = false) "
+							+ "AND (a.name LIKE :searchtext OR a.owner.userName LIKE :searchtext)"
 					),
 			@NamedQuery(
 					name = "Alert.countPrivateAlertsForPrivilegedUser",
@@ -177,7 +179,8 @@ import com.salesforce.dva.argus.service.metric.MetricReader;
 					),
 			@NamedQuery(
 					name = "Alert.countPrivateAlertsForPrivilegedUserWithSearchText",
-					query = "SELECT count(a) from Alert a where a.shared = false AND a.id in (SELECT jpa.id from JPAEntity jpa where jpa.deleted = false) AND (a.name LIKE :searchtext OR a.owner.userName LIKE :searchtext)"
+					query = "SELECT count(a) from Alert a where a.shared = false AND a.id in (SELECT jpa.id from JPAEntity jpa where jpa.deleted = false) "
+							+ "AND (a.name LIKE :searchtext OR a.owner.userName LIKE :searchtext)"
 					),
 		}
 		)
@@ -339,6 +342,10 @@ public class Alert extends JPAEntity implements Serializable, CronJob {
 	public static int countByOwner(EntityManager em, PrincipalUser owner, String searchText) {
 		requireArgument(em != null, "Entity manager can not be null.");
 		requireArgument(owner != null, "Owner cannot be null.");
+		
+		if (searchText != null) {
+			searchText.trim();
+		}
 
 		try {
 			TypedQuery<Long> query = null;
@@ -405,6 +412,10 @@ public class Alert extends JPAEntity implements Serializable, CronJob {
 			Integer offset, String searchText) {
 		requireArgument(em != null, "Entity manager can not be null.");
 		requireArgument(owner != null, "Owner cannot be null");
+		
+		if (searchText != null) {
+			searchText.trim();
+		}
 		
 		if (limit == null || limit <= 0) {
 			limit = DEFAULT_PAGE_LIMIT;
@@ -662,6 +673,10 @@ public class Alert extends JPAEntity implements Serializable, CronJob {
 	 */
 	public static int countSharedAlerts(EntityManager em, String searchText) {
 		requireArgument(em != null, "Entity manager can not be null.");
+		
+		if (searchText != null) {
+			searchText.trim();
+		}
 
 		try {
 			TypedQuery<Long> query = null;
@@ -728,6 +743,11 @@ public class Alert extends JPAEntity implements Serializable, CronJob {
 	 */
 	public static List<Alert> findSharedAlertsMetaPaged(EntityManager em, Integer limit, Integer offset, String searchText) {
 		requireArgument(em != null, "Entity manager can not be null.");
+		
+		if (searchText != null) {
+			searchText.trim();
+		}
+		
 		if (limit == null || limit <= 0) {
 			limit = DEFAULT_PAGE_LIMIT;
 		}
@@ -762,6 +782,11 @@ public class Alert extends JPAEntity implements Serializable, CronJob {
 	 */
 	public static List<Alert> findPrivateAlertsForPrivilegedUserMetaPaged(EntityManager em, PrincipalUser owner, Integer limit, Integer offset, String searchText) {
 		requireArgument(em != null, "Entity manager can not be null.");
+		
+		if (searchText != null) {
+			searchText.trim();
+		}
+		
 		if (limit == null || limit <= 0) {
 			limit = DEFAULT_PAGE_LIMIT;
 		}
@@ -803,6 +828,10 @@ public class Alert extends JPAEntity implements Serializable, CronJob {
 	public static int countPrivateAlertsForPrivilegedUser(EntityManager em, PrincipalUser owner, String searchText) {
 		requireArgument(em != null, "Entity manager can not be null.");
 		requireArgument(owner != null, "Owner cannot be null.");
+		
+		if (searchText != null) {
+			searchText.trim();
+		}
 
 		if (!owner.isPrivileged()) {
 			return 0;

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/entity/Alert.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/entity/Alert.java
@@ -64,6 +64,7 @@ import javax.persistence.TypedQuery;
 import javax.persistence.UniqueConstraint;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Expression;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import javax.persistence.criteria.Selection;
@@ -104,6 +105,7 @@ import com.salesforce.dva.argus.service.metric.MetricReader;
  * @author  Tom Valine (tvaline@salesforce.com)
  * @author  Raj Sarkapally (rsarkapally@salesforce.com)
  * @author	Bhinav Sura (bhinav.sura@salesforce.com)
+ * @author  Dongpu Jin (djin@salesforce.com)
  */
 @SuppressWarnings("serial")
 @Entity
@@ -158,13 +160,25 @@ import com.salesforce.dva.argus.service.metric.MetricReader;
 					query = "SELECT count(a) FROM Alert a WHERE a.owner = :owner AND a.id in (SELECT jpa.id from JPAEntity jpa where jpa.deleted = false)"
 					),
 			@NamedQuery(
+					name = "Alert.countByOwnerWithSearchText",
+					query = "SELECT count(a) FROM Alert a WHERE a.owner = :owner AND a.id in (SELECT jpa.id from JPAEntity jpa where jpa.deleted = false) AND (a.name LIKE :searchtext OR a.owner.userName LIKE :searchtext)"
+					),
+			@NamedQuery(
 					name = "Alert.countSharedAlerts",
 					query = "SELECT count(a) from Alert a where a.shared = true AND a.id in (SELECT jpa.id from JPAEntity jpa where jpa.deleted = false)"
 					),
 			@NamedQuery(
+					name = "Alert.countSharedAlertsWithSearchText",
+					query = "SELECT count(a) FROM Alert a WHERE a.shared = true AND a.id IN (SELECT jpa.id FROM JPAEntity jpa WHERE jpa.deleted = false) AND (a.name LIKE :searchtext OR a.owner.userName LIKE :searchtext)"
+					),
+			@NamedQuery(
 					name = "Alert.countPrivateAlertsForPrivilegedUser",
 					query = "SELECT count(a) from Alert a where a.shared = false AND a.id in (SELECT jpa.id from JPAEntity jpa where jpa.deleted = false)"
-					)
+					),
+			@NamedQuery(
+					name = "Alert.countPrivateAlertsForPrivilegedUserWithSearchText",
+					query = "SELECT count(a) from Alert a where a.shared = false AND a.id in (SELECT jpa.id from JPAEntity jpa where jpa.deleted = false) AND (a.name LIKE :searchtext OR a.owner.userName LIKE :searchtext)"
+					),
 		}
 		)
 public class Alert extends JPAEntity implements Serializable, CronJob {
@@ -212,6 +226,7 @@ public class Alert extends JPAEntity implements Serializable, CronJob {
 	private static String DELETED_KEY = "deleted";
 	private static String SHARED_KEY = "shared";
 	private static String OWNER_KEY = "owner";
+	private static String SEARCHTEXT_KEY = "searchtext";
 
 	//~ Constructors *********************************************************************************************************************************
 
@@ -316,18 +331,29 @@ public class Alert extends JPAEntity implements Serializable, CronJob {
 	 *            The entity manager to user. Cannot be null.
 	 * @param owner
 	 *            owner The owner to retrieve alerts for. Cannot be null.
+	 * @param searchText
+	 * 			  The text to filter the search results.
 	 *
 	 * @return The total number of alerts for the owner.
 	 */
-	public static int countByOwner(EntityManager em, PrincipalUser owner) {
+	public static int countByOwner(EntityManager em, PrincipalUser owner, String searchText) {
 		requireArgument(em != null, "Entity manager can not be null.");
 		requireArgument(owner != null, "Owner cannot be null.");
 
-		TypedQuery<Long> query = em.createNamedQuery("Alert.countByOwner", Long.class);
-		query.setHint(QueryHints.REFRESH, HintValues.TRUE);
-		query.setHint("javax.persistence.cache.storeMode", "REFRESH");
 		try {
-			query.setParameter("owner", owner);
+			TypedQuery<Long> query = null;
+
+			if (searchText == null || searchText.isEmpty()) {
+				query = em.createNamedQuery("Alert.countByOwner", Long.class);
+			} else {
+				query = em.createNamedQuery("Alert.countByOwnerWithSearchText", Long.class);
+				query.setParameter(SEARCHTEXT_KEY, "%" + searchText + "%");
+			}
+
+			query.setHint(QueryHints.REFRESH, HintValues.TRUE);
+			query.setHint("javax.persistence.cache.storeMode", "REFRESH");
+			query.setParameter(OWNER_KEY, owner);
+
 			return query.getSingleResult().intValue();
 		} catch (NoResultException ex) {
 			return 0;
@@ -353,7 +379,7 @@ public class Alert extends JPAEntity implements Serializable, CronJob {
 			whereParams.put(OWNER_KEY, owner);
 
 			// Get alerts meta
-			return getAlertsMetaPaged(em, null, null, whereParams);
+			return getAlertsMetaPaged(em, null, null, whereParams, null);
 		} catch (NoResultException ex) {
 			return new ArrayList<>(0);
 		}
@@ -370,11 +396,13 @@ public class Alert extends JPAEntity implements Serializable, CronJob {
 	 *            The limit of return to return.
 	 * @param offset
 	 *            The starting offset of the result.
+	 * @param searchText
+	 * 			  The text to filter the search results.
 	 *
 	 * @return The list of alerts for the owner.
 	 */
 	public static List<Alert> findByOwnerMetaPaged(EntityManager em, PrincipalUser owner, Integer limit,
-			Integer offset) {
+			Integer offset, String searchText) {
 		requireArgument(em != null, "Entity manager can not be null.");
 		requireArgument(owner != null, "Owner cannot be null");
 		
@@ -391,7 +419,7 @@ public class Alert extends JPAEntity implements Serializable, CronJob {
 			whereParams.put(OWNER_KEY, owner);
 
 			// Get alerts meta
-			return getAlertsMetaPaged(em, limit, offset, whereParams);
+			return getAlertsMetaPaged(em, limit, offset, whereParams, searchText);
 		} catch (NoResultException ex) {
 			return new ArrayList<>(0);
 		}
@@ -432,7 +460,7 @@ public class Alert extends JPAEntity implements Serializable, CronJob {
 			whereParams.put(DELETED_KEY, false);
 
 			// Get alerts meta
-			return getAlertsMetaPaged(em, null, null, whereParams);
+			return getAlertsMetaPaged(em, null, null, whereParams, null);
 		} catch (NoResultException ex) {
 			return new ArrayList<>(0);
 		}
@@ -627,16 +655,27 @@ public class Alert extends JPAEntity implements Serializable, CronJob {
 	 *
 	 * @param em
 	 *            The entity manager to user. Cannot be null.
+	 * @param searchText
+	 * 			  The text to filter the search results.
 	 *
 	 * @return The count of all shared alerts.
 	 */
-	public static int countSharedAlerts(EntityManager em) {
+	public static int countSharedAlerts(EntityManager em, String searchText) {
 		requireArgument(em != null, "Entity manager can not be null.");
 
-		TypedQuery<Long> query = em.createNamedQuery("Alert.countSharedAlerts", Long.class);
-		query.setHint(QueryHints.REFRESH, HintValues.TRUE);
-		query.setHint("javax.persistence.cache.storeMode", "REFRESH");
 		try {
+			TypedQuery<Long> query = null;
+
+			if (searchText == null || searchText.isEmpty()) {
+				query = em.createNamedQuery("Alert.countSharedAlerts", Long.class);
+			} else {
+				query = em.createNamedQuery("Alert.countSharedAlertsWithSearchText", Long.class);
+				query.setParameter(SEARCHTEXT_KEY, "%" + searchText + "%");
+			}
+
+			query.setHint(QueryHints.REFRESH, HintValues.TRUE);
+			query.setHint("javax.persistence.cache.storeMode", "REFRESH");
+
 			return query.getSingleResult().intValue();
 		} catch (NoResultException ex) {
 			return 0;
@@ -665,7 +704,7 @@ public class Alert extends JPAEntity implements Serializable, CronJob {
 			}
 
 			// Get alerts meta
-			return getAlertsMetaPaged(em, limit, null, whereParams);
+			return getAlertsMetaPaged(em, limit, null, whereParams, null);
 		} catch (NoResultException ex) {
 			return new ArrayList<>(0);
 		}
@@ -682,10 +721,12 @@ public class Alert extends JPAEntity implements Serializable, CronJob {
 	 *            The maximum number of rows to return.
 	 * @param offset
 	 *            The starting offset of the result.
+	 * @param searchText
+	 * 			  The text to filter the search results.
 	 * 
 	 * @return The list of shared alerts with given limit and offset.
 	 */
-	public static List<Alert> findSharedAlertsMetaPaged(EntityManager em, Integer limit, Integer offset) {
+	public static List<Alert> findSharedAlertsMetaPaged(EntityManager em, Integer limit, Integer offset, String searchText) {
 		requireArgument(em != null, "Entity manager can not be null.");
 		if (limit == null || limit <= 0) {
 			limit = DEFAULT_PAGE_LIMIT;
@@ -701,7 +742,7 @@ public class Alert extends JPAEntity implements Serializable, CronJob {
 			whereParams.put(SHARED_KEY, true);
 
 			// Get alerts meta
-			return getAlertsMetaPaged(em, limit, offset, whereParams);
+			return getAlertsMetaPaged(em, limit, offset, whereParams, searchText);
 		} catch (NoResultException ex) {
 			return new ArrayList<>(0);
 		}
@@ -714,10 +755,12 @@ public class Alert extends JPAEntity implements Serializable, CronJob {
 	 * @param   owner  The owner to filter on 
 	 * @param   limit  The maximum number of rows to return.
 	 * @param 	offset The starting offset of the result.
+	 * @param searchText
+	 * 			  The text to filter the search results.
 	 *
 	 * @return The list of private alerts' meta with given limit and offset.
 	 */
-	public static List<Alert> findPrivateAlertsForPrivilegedUserMetaPaged(EntityManager em, PrincipalUser owner, Integer limit, Integer offset) {
+	public static List<Alert> findPrivateAlertsForPrivilegedUserMetaPaged(EntityManager em, PrincipalUser owner, Integer limit, Integer offset, String searchText) {
 		requireArgument(em != null, "Entity manager can not be null.");
 		if (limit == null || limit <= 0) {
 			limit = DEFAULT_PAGE_LIMIT;
@@ -738,7 +781,7 @@ public class Alert extends JPAEntity implements Serializable, CronJob {
 			whereParams.put(SHARED_KEY, false);
 
 			// Get alerts meta
-			return getAlertsMetaPaged(em, limit, offset, whereParams);
+			return getAlertsMetaPaged(em, limit, offset, whereParams, searchText);
 		} catch (NoResultException ex) {
 			return new ArrayList<>(0);
 		}
@@ -752,25 +795,36 @@ public class Alert extends JPAEntity implements Serializable, CronJob {
 	 *            The entity manager to user. Cannot be null.
 	 * @param owner
 	 *            The owner to filter on.
+	 * @param searchText
+	 * 			  The text to filter the search results.
 	 * 
 	 * @return The total number of private alerts for privileged user.
 	 */
-	public static int countPrivateAlertsForPrivilegedUser(EntityManager em, PrincipalUser owner) {
+	public static int countPrivateAlertsForPrivilegedUser(EntityManager em, PrincipalUser owner, String searchText) {
 		requireArgument(em != null, "Entity manager can not be null.");
 		requireArgument(owner != null, "Owner cannot be null.");
 
 		if (!owner.isPrivileged()) {
 			return 0;
 		}
-
-		TypedQuery<Long> query = em.createNamedQuery("Alert.countPrivateAlertsForPrivilegedUser", Long.class);
-		query.setHint(QueryHints.REFRESH, HintValues.TRUE);
-		query.setHint("javax.persistence.cache.storeMode", "REFRESH");
+		
 		try {
+			TypedQuery<Long> query = null;
+
+			if (searchText == null || searchText.isEmpty()) {
+				query = em.createNamedQuery("Alert.countPrivateAlertsForPrivilegedUser", Long.class);
+			} else {
+				query = em.createNamedQuery("Alert.countPrivateAlertsForPrivilegedUserWithSearchText", Long.class);
+				query.setParameter(SEARCHTEXT_KEY, "%" + searchText + "%");
+			}
+
+			query.setHint(QueryHints.REFRESH, HintValues.TRUE);
+			query.setHint("javax.persistence.cache.storeMode", "REFRESH");
+
 			return query.getSingleResult().intValue();
 		} catch (NoResultException ex) {
 			return 0;
-		}
+		} 
 	}
 
 	/**
@@ -803,7 +857,7 @@ public class Alert extends JPAEntity implements Serializable, CronJob {
 	 * limit and offset.
 	 */
 	private static List<Alert> getAlertsMetaPaged(EntityManager em, Integer limit, Integer offset,
-			Map<String, Object> whereParams) {
+			Map<String, Object> whereParams, String searchText) {
 		CriteriaBuilder cb = em.getCriteriaBuilder();
 		CriteriaQuery<Tuple> cq = cb.createTupleQuery();
 		Root<Alert> e = cq.from(Alert.class);
@@ -815,11 +869,11 @@ public class Alert extends JPAEntity implements Serializable, CronJob {
 		}
 		cq.multiselect(fieldsToSelect);
 
-		// Set where conditions, so far we only use boolean and PrincipalUser
+		List<Predicate> predicates = new ArrayList<>();
+		
+		// Set WHERE conditions, so far we only use boolean and PrincipalUser
 		// type conditions. New types can be easily added here on demand.
 		if (whereParams != null && whereParams.size() > 0) {
-			List<Predicate> predicates = new ArrayList<>();
-
 			for (String key : whereParams.keySet()) {
 				Object value = whereParams.get(key);
 				if (value instanceof Boolean) {
@@ -831,10 +885,18 @@ public class Alert extends JPAEntity implements Serializable, CronJob {
 					predicates.add(cb.equal(e.get(key), (PrincipalUser) value));
 				}
 			}
-
-			if (predicates.size() > 0) {
-				cq.where(predicates.toArray(new Predicate[predicates.size()]));
-			}
+		}
+		
+		// Filter on alert name and owner name if not empty
+		if (searchText != null && !searchText.isEmpty()) {
+			String searchPattern = "%" + searchText + "%";
+			Expression<String> alertName = e.get("name");
+			Expression<String> ownerName = e.join("owner").get("userName");
+			predicates.add(cb.or(cb.like(alertName, searchPattern), cb.like(ownerName, searchPattern)));
+		}
+		
+		if (predicates.size() > 0) {
+			cq.where(predicates.toArray(new Predicate[predicates.size()]));
 		}
 
 		// Sort result by alert id
@@ -871,6 +933,11 @@ public class Alert extends JPAEntity implements Serializable, CronJob {
 			a.modifiedBy = PrincipalUser.class.cast(tuple.get("modifiedBy"));
 
 			alerts.add(a);
+		}
+		
+		// Trim excessive items more then limit in the end
+		if (limit != null && limit > 0) {
+			alerts = alerts.subList(0, Math.min(alerts.size(), limit));
 		}
 
 		return alerts;

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/AlertService.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/AlertService.java
@@ -50,7 +50,7 @@ import java.util.Properties;
 /**
  * Provides methods to create, update and delete alerts.
  *
- * @author  Tom Valine (tvaline@salesforce.com), Raj sarkapally (rsarkapally@salesforce.com)
+ * @author  Tom Valine (tvaline@salesforce.com), Raj sarkapally (rsarkapally@salesforce.com), Dongpu Jin (djin@salesforce.com)
  */
 public interface AlertService extends Service {
 
@@ -144,11 +144,12 @@ public interface AlertService extends Service {
 	 * @param owner The owner to return alerts for. Cannot be null.
 	 * @param limit The number of items to fetch.
 	 * @param offset The starting point of current page.
+	 * @param searchText The text to filter on the search results if not null or empty.
 	 *
 	 * @return The list of alerts.
 	 */
-	List<Alert> findAlertsByOwnerPaged(PrincipalUser owner, Integer limit, Integer offset);
-
+	List<Alert> findAlertsByOwnerPaged(PrincipalUser owner, Integer limit, Integer offset, String searchText);
+	
 	/**
 	 * Returns a list of alerts that have been marked for deletion.
 	 *
@@ -285,10 +286,11 @@ public interface AlertService extends Service {
 	 * 
 	 * @param limit The number of items to fetch.
 	 * @param offset The starting point of current page.
+	 * @param searchText The text to filter on the search results if not null or empty.
 	 *
 	 * @return The list of shared alerts.
 	 */
-	List<Alert> findSharedAlertsPaged(Integer limit, Integer offset);
+	List<Alert> findSharedAlertsPaged(Integer limit, Integer offset, String searchText);
 
 	/**
 	 * Returns the list of supported notifiers.
@@ -319,10 +321,11 @@ public interface AlertService extends Service {
 	 * @param owner The owner to filter on.
 	 * @param limit The number of items to fetch.
 	 * @param offset The starting point of current page.
+	 * @param searchText The text to filter on the search results if not null or empty.
 	 *
 	 * @return The list of private alerts if privileged user.
 	 */
-	List<Alert> findPrivateAlertsForPrivilegedUserPaged(PrincipalUser owner, Integer limit, Integer offset);
+	List<Alert> findPrivateAlertsForPrivilegedUserPaged(PrincipalUser owner, Integer limit, Integer offset, String searchText);
 	
 	/**
 	 * Count alerts with the given AlertsCountContext.

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/alert/AlertsCountContext.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/alert/AlertsCountContext.java
@@ -53,12 +53,16 @@ public class AlertsCountContext {
 	// Current owner
 	private PrincipalUser owner;
 
+	// Search text
+	private String searchText;
+
 	// Constructor
 	private AlertsCountContext(AlertsCountContextBuilder builder) {
 		this.countUserAlerts = builder.userAlerts;
 		this.countSharedAlerts = builder.sharedAlerts;
 		this.countPrivateAlerts = builder.privateAlerts;
 		this.owner = builder.owner;
+		this.searchText = builder.searchText;
 	}
 
 	public boolean isCountUserAlerts() {
@@ -80,12 +84,17 @@ public class AlertsCountContext {
 		return owner;
 	}
 
+	public String getSearchText() {
+		return searchText;
+	}
+
 	// Builder for the context.
 	public static class AlertsCountContextBuilder {
 		private boolean userAlerts = false;
 		private boolean sharedAlerts = false;
 		private boolean privateAlerts = false;
 		private PrincipalUser owner = null;
+		private String searchText = null;
 
 		public AlertsCountContextBuilder countUserAlerts() {
 			this.userAlerts = true;
@@ -104,6 +113,11 @@ public class AlertsCountContext {
 
 		public AlertsCountContextBuilder setPrincipalUser(PrincipalUser owner) {
 			this.owner = owner;
+			return this;
+		}
+
+		public AlertsCountContextBuilder setSearchText(String searchText) {
+			this.searchText = searchText;
 			return this;
 		}
 

--- a/ArgusCore/src/test/java/com/salesforce/dva/argus/service/AlertServiceTest.java
+++ b/ArgusCore/src/test/java/com/salesforce/dva/argus/service/AlertServiceTest.java
@@ -238,22 +238,22 @@ public class AlertServiceTest extends AbstractTest {
 		List<Alert> actualAlerts = new ArrayList<>();
 		
 		// Fetch first page
-		List<Alert> page = alertService.findAlertsByOwnerPaged(user, limit, 0);
+		List<Alert> page = alertService.findAlertsByOwnerPaged(user, limit, 0, null);
 		assertEquals(page.size(), limit);
 		actualAlerts.addAll(page);
 
 		// Fetch second page
-		page = alertService.findAlertsByOwnerPaged(user, limit, actualAlerts.size());
+		page = alertService.findAlertsByOwnerPaged(user, limit, actualAlerts.size(), null);
 		assertEquals(page.size(), limit);
 		actualAlerts.addAll(page); 
 		
 		// Fetch remaining alerts (less than a page)
-		page = alertService.findAlertsByOwnerPaged(user, limit, actualAlerts.size());
+		page = alertService.findAlertsByOwnerPaged(user, limit, actualAlerts.size(), null);
 		assertEquals(page.size(), expectedAlerts.size() - actualAlerts.size());
 		actualAlerts.addAll(page);
 		
 		// Try to fetch again should be empty result
-		page = alertService.findAlertsByOwnerPaged(user, limit, actualAlerts.size());
+		page = alertService.findAlertsByOwnerPaged(user, limit, actualAlerts.size(), null);
 		assertEquals(0, page.size());
 		
 		Set<Alert> actualSet = new HashSet<>();
@@ -261,6 +261,100 @@ public class AlertServiceTest extends AbstractTest {
 		actualSet.addAll(actualAlerts);
 		for (Alert alert : expectedAlerts) {
 			assertTrue(actualSet.contains(alert));
+		}
+	}
+	
+	@Test
+	public void testFindAlertsByOwnerPagedWithSearchText() {
+		UserService userService = system.getServiceFactory().getUserService();
+		AlertService alertService = system.getServiceFactory().getAlertService();
+		String userName = createRandomName();
+		int alertsCount = 25;
+		PrincipalUser user = new PrincipalUser(admin, userName, userName + "@testcompany.com");
+
+		user = userService.updateUser(user);
+
+		List<Alert> expectedAlerts = new ArrayList<>();
+		List<Alert> expectedEvenAlerts = new ArrayList<>(); 
+		List<Alert> expectedOddAlerts = new ArrayList<>();
+
+		for (int i = 0; i < alertsCount; i++) {
+			if (i % 2 == 0) {
+				Alert evenAlert = alertService.updateAlert(new Alert(user, user, "even_alert_" + i, EXPRESSION, "* * * * *"));
+				expectedAlerts.add(evenAlert);
+				expectedEvenAlerts.add(evenAlert);
+			} else {
+				Alert oddAlert = alertService.updateAlert(new Alert(user, user, "odd_alert_" + i, EXPRESSION, "* * * * *"));
+				expectedAlerts.add(oddAlert);
+				expectedOddAlerts.add(oddAlert);
+			}
+		}
+
+		// ==================================================
+		// Test search by owner's name
+		// ==================================================
+		int limit = 10; // Page size
+		List<Alert> actualAlerts = new ArrayList<>();
+
+		// Fetch first page
+		List<Alert> page = alertService.findAlertsByOwnerPaged(user, limit, 0, userName);
+		assertEquals(page.size(), limit);
+		actualAlerts.addAll(page);
+
+		// Fetch with invalid owner's name should be empty
+		page = alertService.findAlertsByOwnerPaged(user, limit, 0, "invalid_owner");
+		assertEquals(page.size(), 0);
+
+		// Fetch second page
+		page = alertService.findAlertsByOwnerPaged(user, limit, actualAlerts.size(), userName);
+		assertEquals(page.size(), limit);
+		actualAlerts.addAll(page);
+
+		// Fetch remaining alerts (less than a page)
+		page = alertService.findAlertsByOwnerPaged(user, limit, actualAlerts.size(), userName);
+		assertEquals(page.size(), expectedAlerts.size() - actualAlerts.size());
+		actualAlerts.addAll(page);
+
+		// Try to fetch again should be empty result
+		page = alertService.findAlertsByOwnerPaged(user, limit, actualAlerts.size(), userName);
+		assertEquals(0, page.size());
+
+		Set<Alert> actualSet = new HashSet<>();
+
+		actualSet.addAll(actualAlerts);
+		for (Alert alert : expectedAlerts) {
+			assertTrue(actualSet.contains(alert));
+		}
+
+		// ==================================================
+		// Test search by alerts name
+		// ==================================================
+		
+		List<Alert> actualEvenAlerts = new ArrayList<>();
+		
+		// Fetch with invalid alert name should be empty
+		page = alertService.findAlertsByOwnerPaged(user, limit, 0, "invalid_alert_name");
+		assertEquals(page.size(), 0);
+
+		// Fetch first page of even number alerts
+		page = alertService.findAlertsByOwnerPaged(user, limit, 0, "even");
+		assertEquals(page.size(), limit);
+		actualEvenAlerts.addAll(page);
+
+		// Fetch second page of even number alerts (less than a page)
+		page = alertService.findAlertsByOwnerPaged(user, limit, actualEvenAlerts.size(), "even");
+		assertEquals(page.size(), expectedEvenAlerts.size() - actualEvenAlerts.size());
+		actualEvenAlerts.addAll(page);
+
+		// Try to fetch again should be empty result
+		page = alertService.findAlertsByOwnerPaged(user, limit, actualEvenAlerts.size(), "even");
+		assertEquals(0, page.size());
+
+		Set<Alert> actualEvenSet = new HashSet<>();
+
+		actualEvenSet.addAll(actualEvenAlerts);
+		for (Alert alert : expectedEvenAlerts) {
+			assertTrue(actualEvenSet.contains(alert));
 		}
 	}
 	
@@ -284,6 +378,54 @@ public class AlertServiceTest extends AbstractTest {
 		int cnt = alertService.countAlerts(context);
 
 		assertEquals(cnt, expectedAlerts.size());
+	}
+	
+	@Test
+	public void testCountAlertsByOwnerWithSearchText() {
+		UserService userService = system.getServiceFactory().getUserService();
+		AlertService alertService = system.getServiceFactory().getAlertService();
+		String userName = createRandomName();
+		int alertsCount = random.nextInt(20) + 1;
+		PrincipalUser user = new PrincipalUser(admin, userName, userName + "@testcompany.com");
+
+		user = userService.updateUser(user);
+
+		List<Alert> expectedAlerts = new ArrayList<>();
+		List<Alert> expectedEvenAlerts = new ArrayList<>(); 
+		List<Alert> expectedOddAlerts = new ArrayList<>();
+
+		for (int i = 0; i < alertsCount; i++) {
+			if (i % 2 == 0) {
+				Alert evenAlert = alertService.updateAlert(new Alert(user, user, "even_alert_" + i, EXPRESSION, "* * * * *"));
+				expectedEvenAlerts.add(evenAlert);
+				expectedAlerts.add(evenAlert);
+			} else {
+				Alert oddAlert = alertService.updateAlert(new Alert(user, user, "odd_alert_" + i, EXPRESSION, "* * * * *"));
+				expectedOddAlerts.add(oddAlert);
+				expectedAlerts.add(oddAlert);
+;			}
+		}
+
+		// Filter on user name
+		AlertsCountContext context = new AlertsCountContext.AlertsCountContextBuilder().countUserAlerts().setPrincipalUser(user).setSearchText(userName).build();
+		int cnt = alertService.countAlerts(context);
+
+		assertEquals(cnt, expectedAlerts.size());
+		
+		// Count alerts have "even" in its name
+		context = new AlertsCountContext.AlertsCountContextBuilder().countUserAlerts().setPrincipalUser(user).setSearchText("even").build();
+		cnt = alertService.countAlerts(context);
+		assertEquals(cnt, expectedEvenAlerts.size());
+		
+		// Count alerts have "odd" in its name
+		context = new AlertsCountContext.AlertsCountContextBuilder().countUserAlerts().setPrincipalUser(user).setSearchText("odd").build();
+		cnt = alertService.countAlerts(context);
+		assertEquals(cnt, expectedOddAlerts.size());
+		
+		// Invalid alert name
+		context = new AlertsCountContext.AlertsCountContextBuilder().countUserAlerts().setPrincipalUser(user).setSearchText("invalid_alert_name").build();
+		cnt = alertService.countAlerts(context);
+		assertEquals(cnt, 0);
 	}
 
 	@Test
@@ -649,17 +791,59 @@ public class AlertServiceTest extends AbstractTest {
 		sharedAlerts.add("alert2");
 		
 		// First page
-		List<Alert> page = alertService.findSharedAlertsPaged(1, 0);
+		List<Alert> page = alertService.findSharedAlertsPaged(1, 0, null);
 		assertEquals(1, page.size());
 		assertTrue(sharedAlerts.contains(page.get(0).getName()));
 		
 		// Second page
-		page = alertService.findSharedAlertsPaged(1, 1);
+		page = alertService.findSharedAlertsPaged(1, 1, null);
 		assertEquals(1, page.size());
 		assertTrue(sharedAlerts.contains(page.get(0).getName()));
 		
 		// Thrid page should be zero
-		page = alertService.findSharedAlertsPaged(1, 2);
+		page = alertService.findSharedAlertsPaged(1, 2, null);
+		assertEquals(0, page.size());
+	}
+	
+	@Test
+	public void testFindSharedAlertsMetaPagedWithSearchText() {
+		UserService userService = system.getServiceFactory().getUserService();
+		AlertService alertService = system.getServiceFactory().getAlertService();
+		PrincipalUser user1 = userService.updateUser(new PrincipalUser(admin, "test1", "test1@salesforce.com"));
+		PrincipalUser user2 = userService.updateUser(new PrincipalUser(admin, "test2", "test2@salesforce.com"));
+
+		Alert alert1 = alertService.updateAlert(new Alert(user1, user1, "alert1", EXPRESSION, "* * * * *"));
+		Alert alert2 = alertService.updateAlert(new Alert(user2, user2, "alert2", EXPRESSION, "* * * * *"));
+		Alert alert3 = alertService.updateAlert(new Alert(user2, user2, "alert3", EXPRESSION, "* * * * *"));
+
+
+		alert1.setShared(true);
+		alertService.updateAlert(alert1);
+		alert2.setShared(true);
+		alertService.updateAlert(alert2);
+		alert3.setShared(false);
+		alertService.updateAlert(alert3);
+		
+		Set<String> sharedAlerts = new HashSet<>();
+		sharedAlerts.add("alert1");
+		sharedAlerts.add("alert2");
+		
+		// Search by owner name
+		List<Alert> page = alertService.findSharedAlertsPaged(10, 0, "test1");
+		assertEquals(1, page.size());
+		assertTrue("test1".equals(page.get(0).getOwner().getUserName()));
+		
+		// Search by alert name
+		page = alertService.findSharedAlertsPaged(10, 0, "alert2");
+		assertEquals(1, page.size());
+		assertTrue("alert2".equals(page.get(0).getName()));
+		
+		// Search private alert
+		page = alertService.findSharedAlertsPaged(1, 2, "alert3");
+		assertEquals(0, page.size());
+		
+		// Invalid search text
+		page = alertService.findSharedAlertsPaged(1, 2, "invalid_search_text");
 		assertEquals(0, page.size());
 	}
 	
@@ -684,6 +868,41 @@ public class AlertServiceTest extends AbstractTest {
 		
 		AlertsCountContext context = new AlertsCountContext.AlertsCountContextBuilder().countSharedAlerts().build();
 		assertEquals(2, alertService.countAlerts(context));
+	}
+	
+	@Test
+	public void testCountSharedAlertsMetaPagedWithSearchText() {
+		UserService userService = system.getServiceFactory().getUserService();
+		AlertService alertService = system.getServiceFactory().getAlertService();
+		PrincipalUser user1 = userService.updateUser(new PrincipalUser(admin, "test1", "test1@salesforce.com"));
+		PrincipalUser user2 = userService.updateUser(new PrincipalUser(admin, "test2", "test2@salesforce.com"));
+
+		Alert alert1 = alertService.updateAlert(new Alert(user1, user1, "alert1", EXPRESSION, "* * * * *"));
+		Alert alert2 = alertService.updateAlert(new Alert(user2, user2, "alert2", EXPRESSION, "* * * * *"));
+		Alert alert3 = alertService.updateAlert(new Alert(user2, user2, "alert3", EXPRESSION, "* * * * *"));
+
+
+		alert1.setShared(true);
+		alertService.updateAlert(alert1);
+		alert2.setShared(true);
+		alertService.updateAlert(alert2);
+		alert3.setShared(false);
+		alertService.updateAlert(alert3);
+		
+		AlertsCountContext context = new AlertsCountContext.AlertsCountContextBuilder().countSharedAlerts().setSearchText("alert").build();
+		assertEquals(2, alertService.countAlerts(context));
+		
+		// count by alert name
+		context = new AlertsCountContext.AlertsCountContextBuilder().countSharedAlerts().setSearchText("alert1").build();
+		assertEquals(1, alertService.countAlerts(context));
+		
+		// count by user name
+		context = new AlertsCountContext.AlertsCountContextBuilder().countSharedAlerts().setSearchText("test1").build();
+		assertEquals(1, alertService.countAlerts(context));
+		
+		// Invalid search text
+		context = new AlertsCountContext.AlertsCountContextBuilder().countSharedAlerts().setSearchText("invalid_search_text").build();
+		assertEquals(0, alertService.countAlerts(context));
 	}
 
 	@Test
@@ -792,7 +1011,7 @@ public class AlertServiceTest extends AbstractTest {
 		alertService.updateAlert(alert3);
 
 		// Assert result is empty for non-privileged user
-		assertEquals(0, alertService.findPrivateAlertsForPrivilegedUserPaged(user1, 100, 0).size());
+		assertEquals(0, alertService.findPrivateAlertsForPrivilegedUserPaged(user1, 100, 0, null).size());
 	}
 	
 	@Test
@@ -846,22 +1065,62 @@ public class AlertServiceTest extends AbstractTest {
 		Set<String> alertNames = new HashSet<>();
 		
 		// Fetch first page
-		List<Alert> page = alertService.findPrivateAlertsForPrivilegedUserPaged(user1, 1, 0);
+		List<Alert> page = alertService.findPrivateAlertsForPrivilegedUserPaged(user1, 1, 0, null);
 		assertEquals(1, page.size());
 		alertNames.add(page.get(0).getName());
 		
 		// Fetch second page
-		page = alertService.findPrivateAlertsForPrivilegedUserPaged(user1, 1, 1);
+		page = alertService.findPrivateAlertsForPrivilegedUserPaged(user1, 1, 1, null);
 		assertEquals(1, page.size());
 		alertNames.add(page.get(0).getName());
 		
 		// Fetch third page, should be empty
-		page = alertService.findPrivateAlertsForPrivilegedUserPaged(user1, 1, 2);
+		page = alertService.findPrivateAlertsForPrivilegedUserPaged(user1, 1, 2, null);
 		assertEquals(0, page.size());
 				
 		// Assert all private alerts are fetched
 		assertTrue(alertNames.contains("alert-name_private1"));
 		assertTrue(alertNames.contains("alert-name-private2"));
+	}
+	
+	@Test
+	public void testFindPrivateAlertsPagedForPrivilegedUserWithSearchText() {
+		UserService userService = system.getServiceFactory().getUserService();
+		AlertService alertService = system.getServiceFactory().getAlertService();
+		ManagementService managementService = system.getServiceFactory().getManagementService();
+		
+		// By default user is not privileged
+		PrincipalUser user1 = userService.updateUser(new PrincipalUser(admin, "test1", "test1@salesforce.com"));
+		managementService.setAdministratorPrivilege(user1, true);
+		PrincipalUser user2 = userService.updateUser(new PrincipalUser(admin, "test2", "test2@salesforce.com"));
+
+
+		Alert alert1 = alertService.updateAlert(new Alert(user1, user1, "alert-name_private1", EXPRESSION, "* * * * *"));
+		Alert alert2 = alertService.updateAlert(new Alert(user2, user2, "alert-name-private2", EXPRESSION, "* * * * *"));
+		Alert alert3 = alertService.updateAlert(new Alert(user2, user2, "alert-name-shared3", EXPRESSION, "* * * * *"));
+
+		alert1.setShared(false);
+		alertService.updateAlert(alert1);
+		alert2.setShared(false);
+		alertService.updateAlert(alert2);
+		alert3.setShared(true);
+		alertService.updateAlert(alert3);
+		
+		// Search by alert name 
+		List<Alert> page = alertService.findPrivateAlertsForPrivilegedUserPaged(user1, 10, 0, "alert-name");
+		assertEquals(2, page.size());
+		
+		page = alertService.findPrivateAlertsForPrivilegedUserPaged(user1, 10, 0, "private1");
+		assertEquals(1, page.size());
+		
+		// Search shared alert name
+		page = alertService.findPrivateAlertsForPrivilegedUserPaged(user1, 10, 0, "shared3");
+		assertEquals(0, page.size());
+		
+		// Search by owner name
+		page = alertService.findPrivateAlertsForPrivilegedUserPaged(user1, 10, 0, "test2");
+		assertEquals(1, page.size());
+		assertEquals("test2", page.get(0).getOwner().getUserName());
 	}
 	
 	@Test
@@ -889,6 +1148,46 @@ public class AlertServiceTest extends AbstractTest {
 		
 		AlertsCountContext context = new AlertsCountContext.AlertsCountContextBuilder().countPrivateAlerts().setPrincipalUser(user1).build();
 		assertEquals(2, alertService.countAlerts(context));
+	}
+	
+	@Test
+	public void testCountPrivateAlertsForPrivilegedUserWithSearchText() {
+		UserService userService = system.getServiceFactory().getUserService();
+		AlertService alertService = system.getServiceFactory().getAlertService();
+		ManagementService managementService = system.getServiceFactory().getManagementService();
+		
+		// By default user is not privileged
+		PrincipalUser user1 = userService.updateUser(new PrincipalUser(admin, "test1", "test1@salesforce.com"));
+		managementService.setAdministratorPrivilege(user1, true);
+		PrincipalUser user2 = userService.updateUser(new PrincipalUser(admin, "test2", "test2@salesforce.com"));
+
+
+		Alert alert1 = alertService.updateAlert(new Alert(user1, user1, "alert-name_private1", EXPRESSION, "* * * * *"));
+		Alert alert2 = alertService.updateAlert(new Alert(user2, user2, "alert-name-private2", EXPRESSION, "* * * * *"));
+		Alert alert3 = alertService.updateAlert(new Alert(user2, user2, "alert-name-shared3", EXPRESSION, "* * * * *"));
+
+		alert1.setShared(false);
+		alertService.updateAlert(alert1);
+		alert2.setShared(false);
+		alertService.updateAlert(alert2);
+		alert3.setShared(true);
+		alertService.updateAlert(alert3);
+		
+		// count by alert name 
+		AlertsCountContext context = new AlertsCountContext.AlertsCountContextBuilder().countPrivateAlerts().setPrincipalUser(user1).setSearchText("alert").build();
+		assertEquals(2, alertService.countAlerts(context));
+		
+		// count by alert name
+		context = new AlertsCountContext.AlertsCountContextBuilder().countPrivateAlerts().setPrincipalUser(user1).setSearchText("alert-name_private1").build();
+		assertEquals(1, alertService.countAlerts(context));
+		
+		// count by owner name
+		context = new AlertsCountContext.AlertsCountContextBuilder().countPrivateAlerts().setPrincipalUser(user1).setSearchText("test2").build();
+		assertEquals(1, alertService.countAlerts(context));
+		
+		// count by invalid name
+		context = new AlertsCountContext.AlertsCountContextBuilder().countPrivateAlerts().setPrincipalUser(user1).setSearchText("invalid_name").build();
+		assertEquals(0, alertService.countAlerts(context));	
 	}
 
 	@Test

--- a/ArgusCore/src/test/java/com/salesforce/dva/argus/service/AlertServiceTest.java
+++ b/ArgusCore/src/test/java/com/salesforce/dva/argus/service/AlertServiceTest.java
@@ -340,6 +340,10 @@ public class AlertServiceTest extends AbstractTest {
 		page = alertService.findAlertsByOwnerPaged(user, limit, 0, "even");
 		assertEquals(page.size(), limit);
 		actualEvenAlerts.addAll(page);
+		
+		// Fetch first page of even number alerts case insensitive
+		page = alertService.findAlertsByOwnerPaged(user, limit, 0, "EvEn");
+		assertEquals(page.size(), limit);
 
 		// Fetch second page of even number alerts (less than a page)
 		page = alertService.findAlertsByOwnerPaged(user, limit, actualEvenAlerts.size(), "even");
@@ -417,8 +421,18 @@ public class AlertServiceTest extends AbstractTest {
 		cnt = alertService.countAlerts(context);
 		assertEquals(cnt, expectedEvenAlerts.size());
 		
+		// Count alerts have "even" in its name case insensitive
+		context = new AlertsCountContext.AlertsCountContextBuilder().countUserAlerts().setPrincipalUser(user).setSearchText("EvEn").build();
+		cnt = alertService.countAlerts(context);
+		assertEquals(cnt, expectedEvenAlerts.size());
+		
 		// Count alerts have "odd" in its name
 		context = new AlertsCountContext.AlertsCountContextBuilder().countUserAlerts().setPrincipalUser(user).setSearchText("odd").build();
+		cnt = alertService.countAlerts(context);
+		assertEquals(cnt, expectedOddAlerts.size());
+		
+		// Count alerts have "odd" in its name
+		context = new AlertsCountContext.AlertsCountContextBuilder().countUserAlerts().setPrincipalUser(user).setSearchText("OdD").build();
 		cnt = alertService.countAlerts(context);
 		assertEquals(cnt, expectedOddAlerts.size());
 		
@@ -833,8 +847,18 @@ public class AlertServiceTest extends AbstractTest {
 		assertEquals(1, page.size());
 		assertTrue("test1".equals(page.get(0).getOwner().getUserName()));
 		
+		// Search by owner name case insensitive
+		page = alertService.findSharedAlertsPaged(10, 0, "TeSt1");
+		assertEquals(1, page.size());
+		assertTrue("test1".equals(page.get(0).getOwner().getUserName()));
+		
 		// Search by alert name
 		page = alertService.findSharedAlertsPaged(10, 0, "alert2");
+		assertEquals(1, page.size());
+		assertTrue("alert2".equals(page.get(0).getName()));
+		
+		// Search by alert name case insensitive
+		page = alertService.findSharedAlertsPaged(10, 0, "aLeRt2");
 		assertEquals(1, page.size());
 		assertTrue("alert2".equals(page.get(0).getName()));
 		
@@ -896,8 +920,16 @@ public class AlertServiceTest extends AbstractTest {
 		context = new AlertsCountContext.AlertsCountContextBuilder().countSharedAlerts().setSearchText("alert1").build();
 		assertEquals(1, alertService.countAlerts(context));
 		
+		// count by alert name case insensitive
+		context = new AlertsCountContext.AlertsCountContextBuilder().countSharedAlerts().setSearchText("aLeRt1").build();
+		assertEquals(1, alertService.countAlerts(context));
+		
 		// count by user name
 		context = new AlertsCountContext.AlertsCountContextBuilder().countSharedAlerts().setSearchText("test1").build();
+		assertEquals(1, alertService.countAlerts(context));
+		
+		// count by user name case insensitive
+		context = new AlertsCountContext.AlertsCountContextBuilder().countSharedAlerts().setSearchText("tEsT1").build();
 		assertEquals(1, alertService.countAlerts(context));
 		
 		// Invalid search text
@@ -1113,12 +1145,28 @@ public class AlertServiceTest extends AbstractTest {
 		page = alertService.findPrivateAlertsForPrivilegedUserPaged(user1, 10, 0, "private1");
 		assertEquals(1, page.size());
 		
+		// Search by alert name case insensitive
+		page = alertService.findPrivateAlertsForPrivilegedUserPaged(user1, 10, 0, "aLerT-NamE");
+		assertEquals(2, page.size());
+		
+		page = alertService.findPrivateAlertsForPrivilegedUserPaged(user1, 10, 0, "PrIvAtE1");
+		assertEquals(1, page.size());
+		
 		// Search shared alert name
 		page = alertService.findPrivateAlertsForPrivilegedUserPaged(user1, 10, 0, "shared3");
 		assertEquals(0, page.size());
 		
+		// Search shared alert name case insensitive
+		page = alertService.findPrivateAlertsForPrivilegedUserPaged(user1, 10, 0, "SHaReD3");
+		assertEquals(0, page.size());
+		
 		// Search by owner name
 		page = alertService.findPrivateAlertsForPrivilegedUserPaged(user1, 10, 0, "test2");
+		assertEquals(1, page.size());
+		assertEquals("test2", page.get(0).getOwner().getUserName());
+		
+		// Search by owner name case insensitive
+		page = alertService.findPrivateAlertsForPrivilegedUserPaged(user1, 10, 0, "TeSt2");
 		assertEquals(1, page.size());
 		assertEquals("test2", page.get(0).getOwner().getUserName());
 	}
@@ -1177,12 +1225,20 @@ public class AlertServiceTest extends AbstractTest {
 		AlertsCountContext context = new AlertsCountContext.AlertsCountContextBuilder().countPrivateAlerts().setPrincipalUser(user1).setSearchText("alert").build();
 		assertEquals(2, alertService.countAlerts(context));
 		
+		// count by alert name case insensitive
+		context = new AlertsCountContext.AlertsCountContextBuilder().countPrivateAlerts().setPrincipalUser(user1).setSearchText("AlErT").build();
+		assertEquals(2, alertService.countAlerts(context));
+		
 		// count by alert name
 		context = new AlertsCountContext.AlertsCountContextBuilder().countPrivateAlerts().setPrincipalUser(user1).setSearchText("alert-name_private1").build();
 		assertEquals(1, alertService.countAlerts(context));
 		
 		// count by owner name
 		context = new AlertsCountContext.AlertsCountContextBuilder().countPrivateAlerts().setPrincipalUser(user1).setSearchText("test2").build();
+		assertEquals(1, alertService.countAlerts(context));
+		
+		// count by owner name case insensitive
+		context = new AlertsCountContext.AlertsCountContextBuilder().countPrivateAlerts().setPrincipalUser(user1).setSearchText("TeST2").build();
 		assertEquals(1, alertService.countAlerts(context));
 		
 		// count by invalid name

--- a/ArgusCore/src/test/java/com/salesforce/dva/argus/service/AlertServiceTest.java
+++ b/ArgusCore/src/test/java/com/salesforce/dva/argus/service/AlertServiceTest.java
@@ -403,7 +403,7 @@ public class AlertServiceTest extends AbstractTest {
 				Alert oddAlert = alertService.updateAlert(new Alert(user, user, "odd_alert_" + i, EXPRESSION, "* * * * *"));
 				expectedOddAlerts.add(oddAlert);
 				expectedAlerts.add(oddAlert);
-;			}
+			}
 		}
 
 		// Filter on user name


### PR DESCRIPTION
Part 2 of alerts pagination. 
This PR adds search capability to paginated alerts APIs. 
**The APIs being updated in this PR has no caller yet, thus this PR does not affect any existing functionality**

- Unit tests added. 
- Manually tested the APIs with experimental UI changes on my local machine. 

TODO
Part 3: UI changes to hook up alerts and search with new APIs. 