### PR TITLE
Options to disable MQService producer or consumer

### DIFF
--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/mq/kafka/Producer.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/mq/kafka/Producer.java
@@ -69,7 +69,7 @@ public class Producer {
 
     private final Logger _logger = LoggerFactory.getLogger(getClass());
     private final SystemConfiguration _configuration;
-    private final KafkaProducer<String, String> _producer;
+    private KafkaProducer<String, String> _producer;
     private final ExecutorService _executorService;
     private final ObjectMapper _mapper;
 


### PR DESCRIPTION
Some ArgusCore-dependent modules (eg. ArgusClient) may not need the specific producer or consumer component of MQService. Before, even if the `Producer.java` class was unused, it would initiate a KafkaProducer connection to brokers; this prevents that if disable option is set to true