### PR TITLE
[W-5386828] adding metrics to help investigation 

### DIFF
--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/MonitorService.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/MonitorService.java
@@ -194,6 +194,8 @@ public interface MonitorService extends Service {
         ALERTS_FAILED("argus.core", "alerts.failed"),
         ALERTS_EVALUATION_LATENCY("argus.core", "alerts.evaluation.latency"),
         ALERTS_SKIPPED("argus.core", "alerts.skipped"),
+        ALERTS_PICKEDUP_LIST_SIZE("argus.core", "alerts.pickedupList.size"),
+        ALERTS_PICKEDUP("argus.core", "alerts.pickedup"),
         NOTIFICATIONS_SENT("argus.core", "notifications.sent"),
         TRIGGERS_VIOLATED("argus.core", "triggers.violated"),
         ALERTS_MAX("argus.core", "alerts.max"),

--- a/ArgusWeb/README.md
+++ b/ArgusWeb/README.md
@@ -49,7 +49,7 @@ $ bower -v
 
 ##### Build Commands
 #
-###### Run npm to build and install:
+###### Run npm to build and install (Note: has run the command under %this_repo%/ArgusWeb/):
 #
 ```sh
 $ npm install


### PR DESCRIPTION
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000005Wd8RIAS/view

Add more metrics to help investigate why alert.scheduled != alert.evaluated when alert.skipped show as zero

The explanation is in the code, and I made small modification to readme.
@sundeepsf 
