### PR TITLE
Upgrade Kafka dependency to 0.9, allow for custom topic names

### DIFF
--- a/ArgusCore/pom.xml
+++ b/ArgusCore/pom.xml
@@ -290,22 +290,6 @@
             <version>2.10.5</version>
         </dependency>
         <dependency>
-            <groupId>com.101tec</groupId>
-            <artifactId>zkclient</artifactId>
-            <version>0.3</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.zookeeper</groupId>
-            <artifactId>zookeeper</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
-            <version>3.4.10</version>
-        </dependency>
-        <dependency>
             <groupId>net.sf.jopt-simple</groupId>
             <artifactId>jopt-simple</artifactId>
             <version>3.2</version>

--- a/ArgusCore/pom.xml
+++ b/ArgusCore/pom.xml
@@ -257,12 +257,12 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.10</artifactId>
-            <version>0.8.2.1</version>
+            <version>0.9.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-           <version>0.8.2.1</version>
+           <version>0.9.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>

--- a/ArgusCore/pom.xml
+++ b/ArgusCore/pom.xml
@@ -258,11 +258,31 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.10</artifactId>
             <version>0.9.0.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
            <version>0.9.0.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/mq/kafka/KafkaMessageService.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/mq/kafka/KafkaMessageService.java
@@ -37,7 +37,6 @@ import com.google.inject.Singleton;
 import com.salesforce.dva.argus.service.DefaultService;
 import com.salesforce.dva.argus.service.MQService;
 import com.salesforce.dva.argus.system.SystemConfiguration;
-import org.apache.kafka.common.config.SslConfigs;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -92,7 +91,7 @@ public class KafkaMessageService extends DefaultService implements MQService {
     }
 
     /*
-     * Transform an MQService MQQueue name to the configured topic name if in .properties file
+     * Transform an MQService MQQueue name to the configured topic name if redefined in .properties file
      */
     private String toKafkaTopic(String topic) {
         if (topic.equals(MQQueue.ALERT.getQueueName())) {

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/mq/kafka/Producer.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/mq/kafka/Producer.java
@@ -148,8 +148,6 @@ public class Producer {
      * @return  The number of objects that were successfully added to the Producer Buffer.
      */
     public <T extends Serializable> int enqueue(final String topic, List<T> objects) {
-        _logger.info("*****\n\n\n\n\n");
-        _logger.info("ENQUEUEING TO TOPIC: " + topic);
         int messagesBuffered = 0;
 
         for (T object : objects) {
@@ -229,15 +227,12 @@ public class Producer {
             ProducerRecord<String, String> record = new ProducerRecord<>(_topic, _message);
 
             try {
-                _logger.info("STARTING PRODUCERWORKER SEND");
                 _producer.send(record, new Callback() {
-
                         @Override
                         public void onCompletion(RecordMetadata metaData, Exception exception) {
                             if (exception != null) {
                                 _logger.warn("Exception while sending message. ", exception);
                             } else {
-                                _logger.info("Message sent to partition {} with offset {}.", metaData.partition(), metaData.offset());
                                 _logger.trace("Message sent to partition {} with offset {}.", metaData.partition(), metaData.offset());
                             }
                         }

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/mq/kafka/Producer.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/mq/kafka/Producer.java
@@ -151,7 +151,6 @@ public class Producer {
         int messagesBuffered = 0;
 
         for (T object : objects) {
-            _logger.info("On object " + object.toString());
             final String value;
 
             if (String.class.isAssignableFrom(object.getClass())) {
@@ -159,14 +158,12 @@ public class Producer {
             } else {
                 try {
                     value = _mapper.writeValueAsString(object);
-                    _logger.info("serialized to: " + value);
                 } catch (JsonProcessingException e) {
                     _logger.warn("Exception while serializing the object to a string. Skipping this object.", e);
                     continue;
                 }
             }
             try {
-                _logger.info("starting executor submit to " + topic);
                 boolean addedToBuffer = _executorService.submit(new ProducerWorker(topic, value)).get();
 
                 if (addedToBuffer) {

--- a/ArgusCore/src/test/java/com/salesforce/dva/argus/AbstractTest.java
+++ b/ArgusCore/src/test/java/com/salesforce/dva/argus/AbstractTest.java
@@ -73,6 +73,8 @@ public abstract class AbstractTest {
         apacheLogger.setLevel(ch.qos.logback.classic.Level.OFF);
         ch.qos.logback.classic.Logger kafkaLogger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger("kafka");
         kafkaLogger.setLevel(ch.qos.logback.classic.Level.OFF);
+        ch.qos.logback.classic.Logger zkLogger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger("org.I0Itec.zkclient");
+        zkLogger.setLevel(ch.qos.logback.classic.Level.OFF);
     }
 
     protected TestingServer zkTestServer;

--- a/ArgusCore/src/test/java/com/salesforce/dva/argus/service/AlertServiceTest.java
+++ b/ArgusCore/src/test/java/com/salesforce/dva/argus/service/AlertServiceTest.java
@@ -712,7 +712,7 @@ public class AlertServiceTest extends AbstractTest {
 		}
 		alertService.enqueueAlerts(actualAlertList);
 
-		List<AlertWithTimestamp> expectedList = mqService.dequeue(ALERT.getQueueName(), AlertWithTimestamp.class, 1000, 10);
+		List<AlertWithTimestamp> expectedList = mqService.dequeue(ALERT.getQueueName(), AlertWithTimestamp.class, 5000, 10);
 
 		assertEquals(actualAlertList.size(), expectedList.size());
 	}


### PR DESCRIPTION
Update: this is being deprioritized until December

Changes:
* Allow connecting to Kafka brokers that require SSL
* Moves to using 
the cleaner ["New Consumer API" introduced in 0.9](http://kafka.apache.org/090/documentation.html#newconsumerapi) 
* Topic names (aka queue names) are now configurable

As a result, numerous properties have been added that are optional if using a plaintext connection:
* `service.property.mq.kafka.security.protocol`
* `service.property.mq.kafka.ssl.truststore.location`
* `service.property.mq.kafka.ssl.truststore.password`
* `service.property.mq.kafka.ssl.keystore.location`
* `service.property.mq.kafka.ssl.keystore.password`
* `service.property.mq.kafka.ssl.key.password`

Setting a custom topic name with:
* `service.property.mq.kafka.alerts.topic`
* `service.property.mq.kafka.annotations.topic`
* `service.property.mq.kafka.metrics.topic`