### PR TITLE
Fix the potential invalid objectname due to metric tags contain "type" key

### DIFF
--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/monitor/CounterMetricJMXExporter.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/monitor/CounterMetricJMXExporter.java
@@ -73,7 +73,7 @@ public class CounterMetricJMXExporter implements GaugeExporter {
 		String objName = "ArgusMetrics:type=Counter,scope=" + metric.getScope() + ",metric=" + metric.getMetric();
 		if (null != metric.getTags()) {
 			for (String key : metric.getTags().keySet()) {
-				objName = objName + "," + key + "=" + metric.getTags().get(key);
+				objName = objName + "," + (key.equalsIgnoreCase("type")? "_type":key) + "=" + metric.getTags().get(key);
 			}
 		}
 		return objName;


### PR DESCRIPTION
JMX exporter program treat all metrics as type=Counter, and if user add another tag called "type" then we will create an invalid MXBean object for JMX.  Here I choose to escape the "type" tag

This issue may affect exporting certain matrix through JMX, but it does not affect anything else.  The exceptions are handled

This is a hotfix.

@naveenreddykarri 
@colbyguan 