### PR TITLE
fix the keyword conflicts in JMX exporter

### DIFF
--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/alert/DefaultAlertService.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/alert/DefaultAlertService.java
@@ -737,12 +737,12 @@ public class DefaultAlertService extends DefaultJPAService implements AlertServi
 
 		Map<String, String> tags = new HashMap<>();
 		tags.put("status", "active");
-		tags.put("type", SupportedNotifier.fromClassName(notification.getNotifierName()).name());
+		tags.put("notify-target", SupportedNotifier.fromClassName(notification.getNotifierName()).name());
 		_monitorService.modifyCounter(Counter.NOTIFICATIONS_SENT, 1, tags);
 		tags = new HashMap<>();
 		tags.put("notification_id", notification.getId().intValue()+"");
 		tags.put("host", HOSTNAME);
-		tags.put("metric", metric.getIdentifier().hashCode()+"");
+		tags.put("metricId", metric.getIdentifier().hashCode()+"");
 		publishAlertTrackingMetric(Counter.NOTIFICATIONS_SENT.getMetric(), trigger.getAlert().getId(), 1.0/*notification sent*/, tags);
 
 		String logMessage = MessageFormat.format("Sent alert notification and updated the cooldown: {0}",
@@ -760,12 +760,12 @@ public class DefaultAlertService extends DefaultJPAService implements AlertServi
 
 		Map<String, String> tags = new HashMap<>();
 		tags.put("status", "clear");
-		tags.put("type", SupportedNotifier.fromClassName(notification.getNotifierName()).name());
+		tags.put("notify-target", SupportedNotifier.fromClassName(notification.getNotifierName()).name());
 		_monitorService.modifyCounter(Counter.NOTIFICATIONS_SENT, 1, tags);
 		tags = new HashMap<>();
 		tags.put("notification_id", notification.getId().intValue()+"");
 		tags.put("host", HOSTNAME);
-		tags.put("metric", metric.getIdentifier().hashCode()+"");
+		tags.put("metricId", metric.getIdentifier().hashCode()+"");
 		publishAlertTrackingMetric(Counter.NOTIFICATIONS_SENT.getMetric(), trigger.getAlert().getId(), -1.0/*notification cleared*/,tags);
 
 		String logMessage = MessageFormat.format("The notification {0} was cleared.", notification.getName());

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/monitor/CounterMetricJMXExporter.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/monitor/CounterMetricJMXExporter.java
@@ -73,7 +73,8 @@ public class CounterMetricJMXExporter implements GaugeExporter {
 		String objName = "ArgusMetrics:type=Counter,scope=" + metric.getScope() + ",metric=" + metric.getMetric();
 		if (null != metric.getTags()) {
 			for (String key : metric.getTags().keySet()) {
-				objName = objName + "," + (key.equalsIgnoreCase("type")? "_type":key) + "=" + metric.getTags().get(key);
+				objName = objName + "," + (key.equalsIgnoreCase("type") || key.equalsIgnoreCase("scope")
+						|| key.equalsIgnoreCase("metric") ? "_" + key : key) + "=" + metric.getTags().get(key);
 			}
 		}
 		return objName;


### PR DESCRIPTION
Avoid the possibility that user use tag that conflict with the build-in keywords of the exporter
This is tested in shared2-argusalertdev1-1-prd.eng.sfdc.net

@sundeepsf 
@naveenreddykarri 