### PR TITLE
Fix Perf regresssion with annotation uid caching

### DIFF
--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/tsdb/AbstractTSDBService.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/tsdb/AbstractTSDBService.java
@@ -202,7 +202,7 @@ public class AbstractTSDBService extends DefaultService implements TSDBService {
 		requireArgument(connTimeout >= 1, "Timeout must be greater than 0.");
 
 		_keyUidCache = CacheBuilder.newBuilder()
-				.maximumSize(100000)
+				.maximumSize(1000000)
 				.expireAfterAccess(1, TimeUnit.HOURS)
 				.build();
 
@@ -451,17 +451,19 @@ public class AbstractTSDBService extends DefaultService implements TSDBService {
 				}
 			}
 
-			// query TSDB to get uids for annotations.
-			Map<String, String> keyUidMap = getUidMapFromTsdb(keyAnnotationMap);
+			if(!keyAnnotationMap.isEmpty()) {
+				// query TSDB to get uids for annotations.
+				Map<String, String> keyUidMap = getUidMapFromTsdb(keyAnnotationMap);
 
-			for(Map.Entry<String, String> keyUidEntry : keyUidMap.entrySet()) {
+				for (Map.Entry<String, String> keyUidEntry : keyUidMap.entrySet()) {
 
-				// We add new uids to the cache and create AnnotationWrapper objects.
-				_keyUidCache.put(keyUidEntry.getKey(), keyUidEntry.getValue());
-				AnnotationWrapper wrapper = new AnnotationWrapper(keyUidEntry.getValue(),
-						keyAnnotationMap.get(keyUidEntry.getKey()));
+					// We add new uids to the cache and create AnnotationWrapper objects.
+					_keyUidCache.put(keyUidEntry.getKey(), keyUidEntry.getValue());
+					AnnotationWrapper wrapper = new AnnotationWrapper(keyUidEntry.getValue(),
+							keyAnnotationMap.get(keyUidEntry.getKey()));
 
-				addToWrapperList(wrapperList, wrapper);
+					addToWrapperList(wrapperList, wrapper);
+				}
 			}
 
 			_logger.debug("putAnnotations CacheStats hitCount {} requestCount {} " +
@@ -528,11 +530,12 @@ public class AbstractTSDBService extends DefaultService implements TSDBService {
 			queries.add(query);
 		}
 
-		long backOff = 1000L;
+		putMetrics(metrics);
+
+		long backOff = 1;
 
 		for (int attempts = 0; attempts < 3; attempts++) {
 
-			putMetrics(metrics);
 			try {
 				Thread.sleep(backOff);
 			} catch (InterruptedException ex) {
@@ -551,7 +554,8 @@ public class AbstractTSDBService extends DefaultService implements TSDBService {
 				return keyUidMap;
 
 			} catch (Exception e) {
-				backOff += 1000L;
+				_logger.warn("Exception while trying to get uids for annotations", e);
+				backOff += 500L;
 			}
 		}
 


### PR DESCRIPTION
[2018-10-31 01:26:52,737] INFO [instrument-metrics-thread] Last 60 seconds:
    annotations.posted 759526.0
    annotations.dropped 0.0
    annotations.consumed 758358.0 (com.salesforce.perfeng.akc.consumer.InstrumentationService)
[2018-10-31 01:26:52,738] INFO [instrument-metrics-thread] Sleeping for 60s before pushing instrumented metrics. (com.salesforce.perfeng.akc.consumer.InstrumentationService)

In prod for group2 annotations the new perf is close to 800K, 20 times what we were seeing previously 40K.